### PR TITLE
🔥 Remove unused overflow error from osmosis swap adapter

### DIFF
--- a/contracts/networks/osmosis/swap/src/error.rs
+++ b/contracts/networks/osmosis/swap/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{OverflowError, StdError};
+use cosmwasm_std::StdError;
 use thiserror::Error;
 
 pub type ContractResult<T> = core::result::Result<T, ContractError>;
@@ -7,9 +7,6 @@ pub type ContractResult<T> = core::result::Result<T, ContractError>;
 pub enum ContractError {
     #[error(transparent)]
     Std(#[from] StdError),
-
-    #[error(transparent)]
-    Overflow(#[from] OverflowError),
 
     #[error(transparent)]
     Payment(#[from] cw_utils::PaymentError),


### PR DESCRIPTION
Closes #12 

This PR removes an unused overflow error.