### PR TITLE
🥅 Improve ibc fee checks to prevent leftover funds on contracts

### DIFF
--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -62,8 +62,8 @@ pub enum ContractError {
     #[error("User Swap Last Swap Operation Denom Out Differs From Min Coin Out Denom")]
     UserSwapOperationsMinCoinDenomMismatch,
 
-    #[error("User Swap Coin In Amount Is Greater Than The Remaining Coin Received")]
-    UserSwapCoinInGreaterThanRemainingReceived,
+    #[error("User Swap Coin In Amount Is Not Equal To The Remaining Coin Received")]
+    UserSwapCoinInNotEqualToRemainingReceived,
 
     ////////////////////////
     /// POST SWAP ACTION ///

--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -43,6 +43,12 @@ pub enum ContractError {
     #[error("Fee Swap Coin Out Denom Differs From Last Denom Out In Swap Operations")]
     FeeSwapOperationsCoinOutDenomMismatch,
 
+    #[error("Fee Swap Coin Out Does Not Equal IBC Fee Coin")]
+    FeeSwapIbcFeeCoinMismatch,
+
+    #[error("IBC Fees Are Provided But Not All The Same Denom")]
+    IbcFeesNotOneCoin,
+
     /////////////////
     /// USER SWAP ///
     /////////////////

--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -43,11 +43,8 @@ pub enum ContractError {
     #[error("Fee Swap Coin Out Denom Differs From Last Denom Out In Swap Operations")]
     FeeSwapOperationsCoinOutDenomMismatch,
 
-    #[error("Fee Swap Coin Out Does Not Equal IBC Fee Coin")]
-    FeeSwapIbcFeeCoinMismatch,
-
-    #[error("IBC Fees Are Provided But Not All The Same Denom")]
-    IbcFeesNotOneCoin,
+    #[error("Fee Swap Coin Out Greater Than IBC Fee")]
+    FeeSwapCoinOutGreaterThanIbcFee,
 
     /////////////////
     /// USER SWAP ///

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -426,7 +426,7 @@ fn verify_and_create_fee_swap_msg(
         return Err(ContractError::FeeSwapOperationsCoinOutDenomMismatch);
     }
 
-    // Convert ibc_fees into a Coins struct 
+    // Convert ibc_fees into a Coins struct
     let ibc_fees: Coins = ibc_fees.clone().try_into()?;
 
     // Verify the fee swap coin out amount less than or equal to the ibc fee amount

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -75,7 +75,8 @@ pub fn execute_swap_and_action(
             .add_message(fee_swap_msg)
             .add_attribute("action", "dispatch_fee_swap");
     } else {
-        // Subtract the relevant denom's ibc fees from the remaining coin received
+        // Deduct the amount of the remaining received coin's denomination that matches
+        // with the IBC fees from the remaining coin received amount
         remaining_coin_received.amount = remaining_coin_received
             .amount
             .checked_sub(ibc_fees.get_amount(&remaining_coin_received.denom))?;

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -7,8 +7,9 @@ use cosmwasm_std::{
 };
 use cw_utils::one_coin;
 use skip::{
+    coins::Coins,
     entry_point::{Affiliate, ExecuteMsg, PostSwapAction},
-    ibc::{Coins, ExecuteMsg as IbcTransferExecuteMsg, IbcInfo, IbcTransfer},
+    ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcInfo, IbcTransfer},
     swap::{
         ExecuteMsg as SwapExecuteMsg, QueryMsg as SwapQueryMsg, SwapExactCoinIn, SwapExactCoinOut,
     },

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 use cw_utils::one_coin;
 use skip::{
     entry_point::{Affiliate, ExecuteMsg, PostSwapAction},
-    ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcFeeMap, IbcInfo, IbcTransfer},
+    ibc::{Coins, ExecuteMsg as IbcTransferExecuteMsg, IbcInfo, IbcTransfer},
     swap::{
         ExecuteMsg as SwapExecuteMsg, QueryMsg as SwapQueryMsg, SwapExactCoinIn, SwapExactCoinOut,
     },
@@ -270,12 +270,12 @@ fn verify_and_create_ibc_transfer_adapter_msg(
     deps.api.addr_validate(&ibc_info.recover_address)?;
 
     // Create the ibc_fees map from the given recv_fee, ack_fee, and timeout_fee
-    let ibc_fees: IbcFeeMap = ibc_info.fee.clone().try_into()?;
+    let ibc_fees_map: Coins = ibc_info.fee.clone().try_into()?;
 
     // Get the amount of the IBC fee payment that matches
     // the denom of the ibc transfer out coin.
     // If there is no denom match, then default to zero.
-    let transfer_out_coin_ibc_fee_amount = ibc_fees.get_amount(&min_coin.denom);
+    let transfer_out_coin_ibc_fee_amount = ibc_fees_map.get_amount(&min_coin.denom);
 
     // Subtract the IBC fee amount from the transfer out coin
     transfer_out_coin.amount = transfer_out_coin
@@ -291,7 +291,7 @@ fn verify_and_create_ibc_transfer_adapter_msg(
     // Calculate the funds to send to the IBC transfer contract
     // (which is the transfer out coin plus the IBC fee amounts)
     // using a map for convenience, and then converting to a vector of coins
-    let mut ibc_msg_funds_map = ibc_fees;
+    let mut ibc_msg_funds_map = ibc_fees_map;
     ibc_msg_funds_map.add_coin(&transfer_out_coin)?;
 
     // Convert the map to a vector of coins

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -56,11 +56,6 @@ pub fn execute_swap_and_action(
 
     // Process the fee swap if it exists
     if let Some(fee_swap) = fee_swap {
-        // Error if the ibc fees is empty since a fee swap is not needed
-        if ibc_fees.is_empty() {
-            return Err(ContractError::FeeSwapNotAllowed);
-        }
-
         // Create the fee swap message
         // NOTE: this call mutates the user swap coin by subtracting the fee swap in amount
         let fee_swap_msg = verify_and_create_fee_swap_msg(
@@ -426,6 +421,11 @@ fn verify_and_create_fee_swap_msg(
     remaining_coin_received: &mut Coin,
     ibc_fees: &Coins,
 ) -> ContractResult<WasmMsg> {
+    // Error if the ibc fees is empty since a fee swap is not needed
+    if ibc_fees.is_empty() {
+        return Err(ContractError::FeeSwapNotAllowed);
+    }
+
     // Verify the swap operations are not empty
     let (Some(first_op), Some(last_op)) = (fee_swap.operations.first(), fee_swap.operations.last()) else {
         return Err(ContractError::FeeSwapOperationsEmpty);

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -402,9 +402,46 @@ struct Params {
             },
         },
         expected_messages: vec![],
-        expected_error: Some(ContractError::UserSwapCoinInGreaterThanRemainingReceived),
+        expected_error: Some(ContractError::UserSwapCoinInNotEqualToRemainingReceived),
     };
     "User Swap Specified Coin More Than Remaining Coin Sent To Contract After Fee Swap - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![
+            Coin::new(1_000_000, "untrn"),
+        ],
+        fee_swap: None,
+        user_swap: SwapExactCoinIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            coin_in: Some(Coin::new(799_999, "untrn")),
+            operations: vec![
+                SwapOperation {
+                    pool: "pool_2".to_string(),
+                    denom_in: "untrn".to_string(),
+                    denom_out: "uatom".to_string(),
+                }
+            ],
+        },
+        min_coin: Coin::new(100_000, "uatom"),
+        timeout_timestamp: 101,
+        post_swap_action: PostSwapAction::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: IbcFee {
+                    recv_fee: vec![],
+                    ack_fee: vec![Coin::new(100_000, "untrn")],
+                    timeout_fee: vec![Coin::new(100_000, "untrn")],
+                },
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+        },
+        expected_messages: vec![],
+        expected_error: Some(ContractError::UserSwapCoinInNotEqualToRemainingReceived),
+    };
+    "User Swap Specified Coin Less Than Remaining Coin Left To Swap - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -688,7 +725,7 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
+            coin_in: Some(Coin::new(1_000_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -714,7 +751,7 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
+            coin_in: Some(Coin::new(1_000_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),

--- a/contracts/networks/osmosis/ibc-transfer/src/error.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/error.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::StdError;
+use cosmwasm_std::{OverflowError, StdError};
 use thiserror::Error;
 
 pub type ContractResult<T> = core::result::Result<T, ContractError>;
@@ -16,6 +16,12 @@ pub enum ContractError {
 
     #[error(transparent)]
     JsonEncode(#[from] serde_json_wasm::ser::Error),
+
+    #[error(transparent)]
+    Overflow(#[from] OverflowError),
+
+    #[error("IBC fees are not supported, vectors must be empty")]
+    IbcFeesNotSupported,
 
     #[error("SubMsgResponse does not contain data")]
     MissingResponseData,

--- a/contracts/networks/osmosis/ibc-transfer/tests/test_execute_ibc_transfer.rs
+++ b/contracts/networks/osmosis/ibc-transfer/tests/test_execute_ibc_transfer.rs
@@ -23,6 +23,7 @@ Expect Response (Output Message Is Correct, In Progress Ibc Transfer Is Saved, N
 
 Expect Error
     - Non Empty String, Invalid Json Memo
+    - Non Empty IBC Fees, IBC Fees Not Supported
 
  */
 
@@ -204,6 +205,33 @@ struct Params {
         expected_error_string: "Object key is not a string.".to_string(),
     };
     "Non Empty String, Invalid Json Memo - Expect Error")]
+#[test_case(
+    Params {
+        ibc_adapter_contract_address: Addr::unchecked("ibc_transfer".to_string()),
+        coin: Coin::new(100, "osmo"),
+        ibc_info: IbcInfo {
+            source_channel: "source_channel".to_string(),
+            receiver: "receiver".to_string(),
+            fee: IbcFee {
+                recv_fee: vec![
+                    Coin::new(100, "atom"),
+                ],
+                ack_fee: vec![],
+                timeout_fee: vec![],
+            },
+            memo: "{}".to_string(),
+            recover_address: "recover_address".to_string(),
+        },
+        timeout_timestamp: 100,
+        expected_messages: vec![],
+        expected_in_progress_ibc_transfer: InProgressIBCTransfer {
+            recover_address: "recover_address".to_string(),
+            coin: Coin::new(100, "osmo"),
+            channel_id: "source_channel".to_string(),
+        },
+        expected_error_string: "IBC fees are not supported, vectors must be empty".to_string(),
+    };
+    "IBC Fees Not Supported - Expect Error")]
 fn test_execute_ibc_transfer(params: Params) -> ContractResult<()> {
     // Create mock dependencies
     let mut deps = mock_dependencies();

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -14,6 +14,11 @@ impl Coins {
 
     // Takes a coin and adds it to the Coins map
     pub fn add_coin(&mut self, coin: &Coin) -> Result<(), OverflowError> {
+        // Do not allow zero amount coin to create a new entry
+        if coin.amount.is_zero() {
+            return Ok(());
+        }
+
         let amount = self
             .0
             .entry(coin.denom.clone())

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -5,12 +5,6 @@ use std::collections::BTreeMap;
 // Coins is a struct that wraps a BTreeMap of String denom to Uint128 total amount
 pub struct Coins(BTreeMap<String, Uint128>);
 
-impl Default for Coins {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 // Implement add coin and get amount methods for Coins struct
 impl Coins {
     // Create a new Coins struct
@@ -62,6 +56,12 @@ impl Coins {
         } else {
             None
         }
+    }
+}
+
+impl Default for Coins {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -28,11 +28,6 @@ impl Coins {
         Ok(())
     }
 
-    // Take a vec of coin objects and adds them to the Coins map
-    pub fn add_coin_vec(&mut self, coin_vec: &[Coin]) -> Result<(), OverflowError> {
-        coin_vec.iter().try_for_each(|coin| self.add_coin(coin))
-    }
-
     // Given a denom, returns the total amount of that denom in the Coins struct
     // or returns 0 if the denom is not in the Coins struct.
     pub fn get_amount(&self, denom: &str) -> Uint128 {
@@ -71,7 +66,8 @@ impl TryFrom<IbcFee> for Coins {
 
         [ibc_fee.recv_fee, ibc_fee.ack_fee, ibc_fee.timeout_fee]
             .iter()
-            .try_for_each(|coins| ibc_fees.add_coin_vec(coins))?;
+            .flatten()
+            .try_for_each(|coin| ibc_fees.add_coin(coin))?;
 
         Ok(ibc_fees)
     }

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -33,6 +33,11 @@ impl Coins {
     pub fn len(&self) -> usize {
         self.0.len()
     }
+
+    // Returns true if Coins map is empty
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 // Converts a Coins struct to a Vec<Coin>

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -38,6 +38,20 @@ impl Coins {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    // Returns an Option of a Coin struct if the Coins map only has one entry
+    // or returns Option None if the Coins map has more than one entry.
+    pub fn one_coin(&self) -> Option<Coin> {
+        if self.len() == 1 {
+            let (denom, amount) = self.0.iter().next().unwrap();
+            Some(Coin {
+                denom: denom.clone(),
+                amount: *amount,
+            })
+        } else {
+            None
+        }
+    }
 }
 
 // Converts a Coins struct to a Vec<Coin>

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -1,0 +1,55 @@
+use crate::ibc::IbcFee;
+use cosmwasm_std::{Coin, OverflowError, Uint128};
+use std::collections::BTreeMap;
+
+// Coins is a struct that wraps a BTreeMap of String denom to Uint128 total amount
+pub struct Coins(BTreeMap<String, Uint128>);
+
+// Converts an IbcFee struct to a Coins struct (BTreeMap<String, Uint128>)
+impl TryFrom<IbcFee> for Coins {
+    type Error = OverflowError;
+
+    fn try_from(ibc_fee: IbcFee) -> Result<Self, Self::Error> {
+        let mut ibc_fees = Coins(BTreeMap::new());
+
+        for coin in [ibc_fee.recv_fee, ibc_fee.ack_fee, ibc_fee.timeout_fee]
+            .iter()
+            .flatten()
+        {
+            ibc_fees.add_coin(coin)?;
+        }
+
+        Ok(ibc_fees)
+    }
+}
+
+// Implement add coin and get amount methods for Coins struct
+impl Coins {
+    // Takes a coin and adds it to the Coins map
+    pub fn add_coin(&mut self, coin: &Coin) -> Result<(), OverflowError> {
+        let amount = self
+            .0
+            .entry(coin.denom.clone())
+            .or_insert_with(Uint128::zero);
+        *amount = amount.checked_add(coin.amount)?;
+
+        Ok(())
+    }
+
+    // Given a denom, returns the total amount of that denom in the Coins struct
+    // or returns 0 if the denom is not in the Coins struct.
+    pub fn get_amount(&self, denom: &str) -> Uint128 {
+        self.0.get(denom).cloned().unwrap_or_default()
+    }
+}
+
+// Converts a Coins struct to a Vec<Coin>
+impl From<Coins> for Vec<Coin> {
+    fn from(coins: Coins) -> Self {
+        coins
+            .0
+            .into_iter()
+            .map(|(denom, amount)| Coin { denom, amount })
+            .collect()
+    }
+}

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -34,28 +34,9 @@ impl Coins {
         self.0.get(denom).cloned().unwrap_or_default()
     }
 
-    // Get length of Coins map
-    pub fn len(&self) -> usize {
-        self.0.len()
-    }
-
     // Returns true if Coins map is empty
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
-    }
-
-    // Returns an Option of a Coin struct if the Coins map only has one entry
-    // or returns Option None if the Coins map has more than one entry.
-    pub fn one_coin(&self) -> Option<Coin> {
-        if self.len() == 1 {
-            let (denom, amount) = self.0.iter().next().unwrap();
-            Some(Coin {
-                denom: denom.clone(),
-                amount: *amount,
-            })
-        } else {
-            None
-        }
     }
 }
 
@@ -73,19 +54,6 @@ impl From<Coins> for Vec<Coin> {
             .into_iter()
             .map(|(denom, amount)| Coin { denom, amount })
             .collect()
-    }
-}
-
-// Converts a Vec<Coin> to a Coins struct
-impl TryFrom<Vec<Coin>> for Coins {
-    type Error = OverflowError;
-
-    fn try_from(coin_vec: Vec<Coin>) -> Result<Self, Self::Error> {
-        let mut coin_map = Coins(BTreeMap::new());
-
-        coin_map.add_coin_vec(&coin_vec)?;
-
-        Ok(coin_map)
     }
 }
 

--- a/packages/skip/src/coins.rs
+++ b/packages/skip/src/coins.rs
@@ -5,8 +5,19 @@ use std::collections::BTreeMap;
 // Coins is a struct that wraps a BTreeMap of String denom to Uint128 total amount
 pub struct Coins(BTreeMap<String, Uint128>);
 
+impl Default for Coins {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // Implement add coin and get amount methods for Coins struct
 impl Coins {
+    // Create a new Coins struct
+    pub fn new() -> Self {
+        Coins(BTreeMap::new())
+    }
+
     // Takes a coin and adds it to the Coins map
     pub fn add_coin(&mut self, coin: &Coin) -> Result<(), OverflowError> {
         let amount = self

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -63,7 +63,7 @@ pub struct IbcFee {
 }
 
 // IbcFeeMap is a type alias for a BTreeMap of String denom to Uint128 total amount
-pub struct IbcFeeMap(pub BTreeMap<String, Uint128>);
+pub struct IbcFeeMap(BTreeMap<String, Uint128>);
 
 // Converts an IbcFee struct to a BTreeMap of String denom to Uint128 total amount
 impl TryFrom<IbcFee> for IbcFeeMap {

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -1,11 +1,8 @@
-use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Coin, OverflowError, Uint128};
-use std::convert::From;
-
-use std::collections::BTreeMap;
-
 use crate::proto_coin::ProtoCoin;
+use cosmwasm_schema::{cw_serde, QueryResponses};
+use cosmwasm_std::Coin;
 use neutron_proto::neutron::feerefunder::Fee as NeutronFee;
+use std::convert::From;
 
 ///////////////////
 /// INSTANTIATE ///
@@ -60,58 +57,6 @@ pub struct IbcFee {
     pub recv_fee: Vec<Coin>,
     pub ack_fee: Vec<Coin>,
     pub timeout_fee: Vec<Coin>,
-}
-
-// Coins is a struct that wraps a BTreeMap of String denom to Uint128 total amount
-pub struct Coins(BTreeMap<String, Uint128>);
-
-// Converts an IbcFee struct to a Coins struct (BTreeMap<String, Uint128>)
-impl TryFrom<IbcFee> for Coins {
-    type Error = OverflowError;
-
-    fn try_from(ibc_fee: IbcFee) -> Result<Self, Self::Error> {
-        let mut ibc_fees = Coins(BTreeMap::new());
-
-        for coin in [ibc_fee.recv_fee, ibc_fee.ack_fee, ibc_fee.timeout_fee]
-            .iter()
-            .flatten()
-        {
-            ibc_fees.add_coin(coin)?;
-        }
-
-        Ok(ibc_fees)
-    }
-}
-
-// Implement add coin and get amount methods for Coins struct
-impl Coins {
-    // Takes a coin and adds it to the Coins map
-    pub fn add_coin(&mut self, coin: &Coin) -> Result<(), OverflowError> {
-        let amount = self
-            .0
-            .entry(coin.denom.clone())
-            .or_insert_with(Uint128::zero);
-        *amount = amount.checked_add(coin.amount)?;
-
-        Ok(())
-    }
-
-    // Given a denom, returns the total amount of that denom in the Coins struct
-    // or returns 0 if the denom is not in the Coins struct.
-    pub fn get_amount(&self, denom: &str) -> Uint128 {
-        self.0.get(denom).cloned().unwrap_or_default()
-    }
-}
-
-// Converts a Coins struct to a Vec<Coin>
-impl From<Coins> for Vec<Coin> {
-    fn from(coins: Coins) -> Self {
-        coins
-            .0
-            .into_iter()
-            .map(|(denom, amount)| Coin { denom, amount })
-            .collect()
-    }
 }
 
 // Converts an IbcFee struct to a neutron_proto Fee

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -62,15 +62,15 @@ pub struct IbcFee {
     pub timeout_fee: Vec<Coin>,
 }
 
-// IbcFeeMap is a type alias for a BTreeMap of String denom to Uint128 total amount
-pub struct IbcFeeMap(BTreeMap<String, Uint128>);
+// Coins is a type alias for a BTreeMap of String denom to Uint128 total amount
+pub struct Coins(BTreeMap<String, Uint128>);
 
 // Converts an IbcFee struct to a BTreeMap of String denom to Uint128 total amount
-impl TryFrom<IbcFee> for IbcFeeMap {
+impl TryFrom<IbcFee> for Coins {
     type Error = OverflowError;
 
     fn try_from(ibc_fee: IbcFee) -> Result<Self, Self::Error> {
-        let mut ibc_fees: IbcFeeMap = IbcFeeMap(BTreeMap::new());
+        let mut ibc_fees = Coins(BTreeMap::new());
 
         for coin in [ibc_fee.recv_fee, ibc_fee.ack_fee, ibc_fee.timeout_fee]
             .iter()
@@ -83,9 +83,9 @@ impl TryFrom<IbcFee> for IbcFeeMap {
     }
 }
 
-// Implement add coin and get amount methods for IbcFeeMap
-impl IbcFeeMap {
-    // Takes a coin and adds it to the IbcFeeMap
+// Implement add coin and get amount methods for Coins
+impl Coins {
+    // Takes a coin and adds it to the Coins map
     pub fn add_coin(&mut self, coin: &Coin) -> Result<(), OverflowError> {
         let amount = self
             .0
@@ -96,17 +96,17 @@ impl IbcFeeMap {
         Ok(())
     }
 
-    // Given a denom, returns the total amount of that denom in the IbcFeeMap
-    // or returns 0 if the denom is not in the IbcFeeMap.
+    // Given a denom, returns the total amount of that denom in the Coins map
+    // or returns 0 if the denom is not in the Coins map.
     pub fn get_amount(&self, denom: &str) -> Uint128 {
         self.0.get(denom).cloned().unwrap_or_default()
     }
 }
 
-// Converts an IbcFeeMap to a Vec<Coin>
-impl From<IbcFeeMap> for Vec<Coin> {
-    fn from(ibc_fee_map: IbcFeeMap) -> Self {
-        ibc_fee_map
+// Converts a Coins map to a Vec<Coin>
+impl From<Coins> for Vec<Coin> {
+    fn from(coins: Coins) -> Self {
+        coins
             .0
             .into_iter()
             .map(|(denom, amount)| Coin { denom, amount })

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -62,10 +62,10 @@ pub struct IbcFee {
     pub timeout_fee: Vec<Coin>,
 }
 
-// Coins is a type alias for a BTreeMap of String denom to Uint128 total amount
+// Coins is a struct that wraps a BTreeMap of String denom to Uint128 total amount
 pub struct Coins(BTreeMap<String, Uint128>);
 
-// Converts an IbcFee struct to a BTreeMap of String denom to Uint128 total amount
+// Converts an IbcFee struct to a Coins struct (BTreeMap<String, Uint128>)
 impl TryFrom<IbcFee> for Coins {
     type Error = OverflowError;
 
@@ -83,7 +83,7 @@ impl TryFrom<IbcFee> for Coins {
     }
 }
 
-// Implement add coin and get amount methods for Coins
+// Implement add coin and get amount methods for Coins struct
 impl Coins {
     // Takes a coin and adds it to the Coins map
     pub fn add_coin(&mut self, coin: &Coin) -> Result<(), OverflowError> {
@@ -96,14 +96,14 @@ impl Coins {
         Ok(())
     }
 
-    // Given a denom, returns the total amount of that denom in the Coins map
-    // or returns 0 if the denom is not in the Coins map.
+    // Given a denom, returns the total amount of that denom in the Coins struct
+    // or returns 0 if the denom is not in the Coins struct.
     pub fn get_amount(&self, denom: &str) -> Uint128 {
         self.0.get(denom).cloned().unwrap_or_default()
     }
 }
 
-// Converts a Coins map to a Vec<Coin>
+// Converts a Coins struct to a Vec<Coin>
 impl From<Coins> for Vec<Coin> {
     fn from(coins: Coins) -> Self {
         coins

--- a/packages/skip/src/lib.rs
+++ b/packages/skip/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod coins;
 pub mod entry_point;
 pub mod ibc;
 pub mod proto_coin;


### PR DESCRIPTION
Closes #5 

This PR improves the contracts ability to prevent left over funds on contract due to malformed requests by the user by:
1. Erroring if ibc fees are are specified while calling the Osmosis ibc transfer adapter contract (since ibc fees are not supported on osmosis)
2. Erroring if the user swap coin would leave funds on the contract
3. Erroring if the fee swap's specified coin out is more than what is required for the ibc fees (which would leave funds on the contract)

This PR also:
1. adds test for each of these cases
2. abstracts the IbcFeeMap into a Coins struct, which will make the transition to the official cosmwasm_std Coins struct easier in the future once 1.3 is released.