### PR TITLE
✨ Refund contract balance in ibc adapters instead of stored vars

### DIFF
--- a/contracts/networks/neutron/ibc-transfer/src/contract.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/contract.rs
@@ -95,7 +95,7 @@ fn execute_ibc_transfer(
         fee: Some(ibc_info.fee.clone().into()),
     };
 
-    // Save in progress ibc transfer data (recover address and coin) to storage, to be used in sudo handler
+    // Save in progress recover address to storage, to be used in sudo handler
     IN_PROGRESS_RECOVER_ADDRESS.save(
         deps.storage,
         &ibc_info.recover_address, // This address is verified in entry point

--- a/contracts/networks/neutron/ibc-transfer/src/error.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/error.rs
@@ -26,7 +26,7 @@ pub enum ContractError {
     #[error("Sequence not found")]
     SequenceNotFound,
 
-    #[error("Failed to receive funds from Neutron to refund the user")]
+    #[error("Failed to receive ibc funds to refund the user")]
     NoFundsToRefund,
 
     #[error("ACK ID already exists for channel ID {channel_id} and sequence ID {sequence_id}")]

--- a/contracts/networks/neutron/ibc-transfer/src/error.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/error.rs
@@ -26,6 +26,9 @@ pub enum ContractError {
     #[error("Sequence not found")]
     SequenceNotFound,
 
+    #[error("Failed to receive funds from Neutron to refund the user")]
+    NoFundsToRefund,
+
     #[error("ACK ID already exists for channel ID {channel_id} and sequence ID {sequence_id}")]
     AckIDAlreadyExists {
         channel_id: String,

--- a/contracts/networks/neutron/ibc-transfer/src/state.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/state.rs
@@ -1,9 +1,7 @@
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
-use skip::ibc::{AckID, NeutronInProgressIbcTransfer as InProgressIbcTransfer};
+use skip::ibc::AckID;
 
 pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");
-pub const IN_PROGRESS_IBC_TRANSFER: Item<InProgressIbcTransfer> =
-    Item::new("in_progress_ibc_transfer");
-pub const ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER: Map<AckID, InProgressIbcTransfer> =
-    Map::new("ack_id_to_transferer");
+pub const IN_PROGRESS_RECOVER_ADDRESS: Item<String> = Item::new("in_progress_recover_address");
+pub const ACK_ID_TO_RECOVER_ADDRESS: Map<AckID, String> = Map::new("ack_id_to_recover_address");

--- a/contracts/networks/neutron/ibc-transfer/tests/test_reply.rs
+++ b/contracts/networks/neutron/ibc-transfer/tests/test_reply.rs
@@ -21,7 +21,6 @@ Expect Error
     - Invalid Sub Msg Response Data To Convert To MsgTransferResponse
     - No In Progress Ibc Transfer To Load
     - Ack ID Already Exists
-    - SubMsg Incorrect Reply ID
 
 Expect Panic
     - SubMsgResult Error

--- a/contracts/networks/neutron/ibc-transfer/tests/test_sudo.rs
+++ b/contracts/networks/neutron/ibc-transfer/tests/test_sudo.rs
@@ -22,7 +22,7 @@ Expect Success
     - Sudo Error - Send Ibc Coin And Timeout Fee Different Denom
 
 Expect Error
-    - No In Progress Ibc Transfer Mapped To Sudo Ack ID - Expect Error
+    - No In Progress Recover Address Mapped To Sudo Ack ID - Expect Error
     - No channel id in TransferSudoMsg - Expect Error
     - No sequence in TransferSudoMsg - Expect Error
     - No Contract Balance To Refund - Expect Error
@@ -337,7 +337,7 @@ fn test_sudo(params: Params) -> ContractResult<()> {
             {
                 Ok(in_progress_recover_address) => {
                     panic!(
-                        "expected in progress ibc transfer to be removed: {:?}",
+                        "expected in progress recover address to be removed: {:?}",
                         in_progress_recover_address
                     )
                 }

--- a/contracts/networks/neutron/ibc-transfer/tests/test_sudo.rs
+++ b/contracts/networks/neutron/ibc-transfer/tests/test_sudo.rs
@@ -26,6 +26,7 @@ Expect Error
     - No In Progress Ibc Transfer Mapped To Sudo Ack ID - Expect Error
     - No channel id in TransferSudoMsg - Expect Error
     - No sequence in TransferSudoMsg - Expect Error
+    - No Contract Balance To Refund - Expect Error
 
  */
 

--- a/contracts/networks/osmosis/ibc-transfer/src/contract.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/contract.rs
@@ -1,7 +1,8 @@
 use crate::{
     error::{ContractError, ContractResult},
     state::{
-        ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER, ENTRY_POINT_CONTRACT_ADDRESS, IN_PROGRESS_IBC_TRANSFER,
+        ACK_ID_TO_RECOVER_ADDRESS, ENTRY_POINT_CONTRACT_ADDRESS, IN_PROGRESS_CHANNEL_ID,
+        IN_PROGRESS_RECOVER_ADDRESS,
     },
 };
 use cosmwasm_std::{
@@ -15,7 +16,7 @@ use skip::{
     coins::Coins,
     ibc::{
         AckID, ExecuteMsg, IbcFee, IbcInfo, IbcLifecycleComplete, InstantiateMsg,
-        OsmosisInProgressIbcTransfer as InProgressIbcTransfer, OsmosisQueryMsg as QueryMsg,
+        OsmosisQueryMsg as QueryMsg,
     },
     proto_coin::ProtoCoin,
     sudo::{OsmosisSudoMsg as SudoMsg, SudoType},
@@ -95,14 +96,16 @@ fn execute_ibc_transfer(
         return Err(ContractError::IbcFeesNotSupported);
     }
 
-    // Save in progress ibc transfer data (recover address and coin) to storage, to be used in sudo handler
-    IN_PROGRESS_IBC_TRANSFER.save(
+    // Save in progress recover address to storage, to be used in sudo handler
+    IN_PROGRESS_RECOVER_ADDRESS.save(
         deps.storage,
-        &InProgressIbcTransfer {
-            recover_address: ibc_info.recover_address, // This address is verified in entry point
-            coin: coin.clone(),
-            channel_id: ibc_info.source_channel.clone(),
-        },
+        &ibc_info.recover_address, // This address is verified in entry point
+    )?;
+
+    // Save in progress channel id to storage, to be used in sudo handler
+    IN_PROGRESS_CHANNEL_ID.save(
+        deps.storage,
+        &ibc_info.source_channel, // This address is verified in entry point
     )?;
 
     // Verify memo is valid json and add the necessary key/value pair to trigger the ibc hooks callback logic.
@@ -167,23 +170,27 @@ pub fn reply(deps: DepsMut, _env: Env, reply: Reply) -> ContractResult<Response>
             .as_slice(),
     )?;
 
-    // Get and delete the in progress ibc transfer from storage
-    let in_progress_ibc_transfer = IN_PROGRESS_IBC_TRANSFER.load(deps.storage)?;
-    IN_PROGRESS_IBC_TRANSFER.remove(deps.storage);
+    // Get and delete the in progress recover address from storage
+    let in_progress_recover_address = IN_PROGRESS_RECOVER_ADDRESS.load(deps.storage)?;
+    IN_PROGRESS_RECOVER_ADDRESS.remove(deps.storage);
+
+    // Get and delete the in progress channel id from storage
+    let in_progress_channel_id = IN_PROGRESS_CHANNEL_ID.load(deps.storage)?;
+    IN_PROGRESS_CHANNEL_ID.remove(deps.storage);
 
     // Set ack_id to be the channel id and sequence id from the response as a tuple
-    let ack_id: AckID = (&in_progress_ibc_transfer.channel_id, resp.sequence);
+    let ack_id: AckID = (&in_progress_channel_id, resp.sequence);
 
     // Error if unique ack_id (channel id, sequence id) already exists in storage
-    if ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.has(deps.storage, ack_id) {
+    if ACK_ID_TO_RECOVER_ADDRESS.has(deps.storage, ack_id) {
         return Err(ContractError::AckIDAlreadyExists {
             channel_id: ack_id.0.into(),
             sequence_id: ack_id.1,
         });
     }
 
-    // Set the in progress ibc transfer to storage, keyed by channel id and sequence id
-    ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.save(deps.storage, ack_id, &in_progress_ibc_transfer)?;
+    // Set the in progress recover address to storage, keyed by channel id and sequence id
+    ACK_ID_TO_RECOVER_ADDRESS.save(deps.storage, ack_id, &in_progress_recover_address)?;
 
     Ok(Response::new().add_attribute("action", "sub_msg_reply_success"))
 }
@@ -210,7 +217,7 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> ContractResult<Response> {
             // since no further action is needed.
             if success {
                 let ack_id: AckID = (&channel, sequence);
-                ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.remove(deps.storage, ack_id);
+                ACK_ID_TO_RECOVER_ADDRESS.remove(deps.storage, ack_id);
 
                 return Ok(Response::new().add_attribute("action", SudoType::Response));
             }
@@ -222,10 +229,10 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> ContractResult<Response> {
         }
     };
 
-    // Get and remove the AckID <> in progress ibc transfer from storage
+    // Get and remove the AckID <> in progress recover address from storage
     let ack_id: AckID = (&channel, sequence);
-    let in_progress_ibc_transfer = ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.load(deps.storage, ack_id)?;
-    ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.remove(deps.storage, ack_id);
+    let to_address = ACK_ID_TO_RECOVER_ADDRESS.load(deps.storage, ack_id)?;
+    ACK_ID_TO_RECOVER_ADDRESS.remove(deps.storage, ack_id);
 
     // Get all coins from contract's balance, which will be the the
     // failed ibc transfer coin and any leftover dust on the contract
@@ -237,10 +244,7 @@ pub fn sudo(deps: DepsMut, env: Env, msg: SudoMsg) -> ContractResult<Response> {
     }
 
     // Create bank send message to send funds back to user's recover address
-    let bank_send_msg = BankMsg::Send {
-        to_address: in_progress_ibc_transfer.recover_address,
-        amount,
-    };
+    let bank_send_msg = BankMsg::Send { to_address, amount };
 
     Ok(Response::new()
         .add_message(bank_send_msg)
@@ -287,12 +291,10 @@ fn verify_and_create_memo(memo: String, contract_address: String) -> ContractRes
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
     match msg {
-        QueryMsg::InProgressIbcTransfer {
+        QueryMsg::InProgressRecoverAddress {
             channel_id,
             sequence_id,
-        } => to_binary(
-            &ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.load(deps.storage, (&channel_id, sequence_id))?,
-        ),
+        } => to_binary(&ACK_ID_TO_RECOVER_ADDRESS.load(deps.storage, (&channel_id, sequence_id))?),
     }
     .map_err(From::from)
 }

--- a/contracts/networks/osmosis/ibc-transfer/src/contract.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/contract.rs
@@ -105,7 +105,7 @@ fn execute_ibc_transfer(
     // Save in progress channel id to storage, to be used in sudo handler
     IN_PROGRESS_CHANNEL_ID.save(
         deps.storage,
-        &ibc_info.source_channel, // This address is verified in entry point
+        &ibc_info.source_channel,
     )?;
 
     // Verify memo is valid json and add the necessary key/value pair to trigger the ibc hooks callback logic.

--- a/contracts/networks/osmosis/ibc-transfer/src/error.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/error.rs
@@ -26,7 +26,7 @@ pub enum ContractError {
     #[error("SubMsgResponse does not contain data")]
     MissingResponseData,
 
-    #[error("Failed to receive funds from Neutron to refund the user")]
+    #[error("Failed to receive ibc funds to refund the user")]
     NoFundsToRefund,
 
     #[error("Unauthorized")]

--- a/contracts/networks/osmosis/ibc-transfer/src/error.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/error.rs
@@ -26,6 +26,9 @@ pub enum ContractError {
     #[error("SubMsgResponse does not contain data")]
     MissingResponseData,
 
+    #[error("Failed to receive funds from Neutron to refund the user")]
+    NoFundsToRefund,
+
     #[error("Unauthorized")]
     Unauthorized,
 

--- a/contracts/networks/osmosis/ibc-transfer/src/state.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/state.rs
@@ -1,9 +1,8 @@
 use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
-use skip::ibc::{AckID, OsmosisInProgressIbcTransfer as InProgressIbcTransfer};
+use skip::ibc::AckID;
 
 pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");
-pub const IN_PROGRESS_IBC_TRANSFER: Item<InProgressIbcTransfer> =
-    Item::new("in_progress_ibc_transfer");
-pub const ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER: Map<AckID, InProgressIbcTransfer> =
-    Map::new("ack_id_to_transferer");
+pub const IN_PROGRESS_RECOVER_ADDRESS: Item<String> = Item::new("in_progress_recover_address");
+pub const IN_PROGRESS_CHANNEL_ID: Item<String> = Item::new("in_progress_channel_id");
+pub const ACK_ID_TO_RECOVER_ADDRESS: Map<AckID, String> = Map::new("ack_id_to_recover_address");

--- a/contracts/networks/osmosis/ibc-transfer/tests/test_reply.rs
+++ b/contracts/networks/osmosis/ibc-transfer/tests/test_reply.rs
@@ -1,13 +1,12 @@
 use cosmwasm_std::{
     testing::{mock_dependencies, mock_env},
-    Coin, Reply, StdError, SubMsgResponse, SubMsgResult,
+    Reply, StdError, SubMsgResponse, SubMsgResult,
 };
 use ibc_proto::ibc::applications::transfer::v1::MsgTransferResponse;
 use prost::Message;
-use skip::ibc::OsmosisInProgressIbcTransfer as InProgressIBCTransfer;
 use skip_swap_osmosis_ibc_transfer::{
     error::ContractResult,
-    state::{ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER, IN_PROGRESS_IBC_TRANSFER},
+    state::{ACK_ID_TO_RECOVER_ADDRESS, IN_PROGRESS_CHANNEL_ID, IN_PROGRESS_RECOVER_ADDRESS},
 };
 use test_case::test_case;
 
@@ -20,9 +19,9 @@ Expect Success
 Expect Error
     - Missing Sub Msg Response Data
     - Invalid Sub Msg Response Data To Convert To MsgTransferResponse
-    - No In Progress Ibc Transfer To Load
+    - No In Progress Recover Address To Load
+    - No In Progress Channel ID To Load
     - Ack ID Already Exists
-    - SubMsg Incorrect Reply ID
 
 Expect Panic
     - SubMsgResult Error
@@ -38,8 +37,9 @@ struct Params {
     channel_id: String,
     sequence_id: u64,
     reply: Reply,
-    pre_reply_in_progress_ibc_transfer: Option<InProgressIBCTransfer>,
-    store_ack_id_to_in_progress_ibc_transfer: bool,
+    pre_reply_in_progress_recover_address: Option<String>,
+    pre_reply_in_progress_channel_id: Option<String>,
+    store_ack_id_to_recover_address: bool,
     expected_error_string: String,
 }
 
@@ -55,12 +55,9 @@ struct Params {
                 data: Some(MsgTransferResponse {sequence: 5}.encode_to_vec().as_slice().into()),
             }),
         },
-        pre_reply_in_progress_ibc_transfer: Some(InProgressIBCTransfer {
-            recover_address: "recover_address".to_string(),
-            coin: Coin::new(100, "osmo"),
-            channel_id: "channel_id".to_string(),
-        }),
-        store_ack_id_to_in_progress_ibc_transfer: false,
+        pre_reply_in_progress_recover_address: Some("recover_address".to_string()),
+        pre_reply_in_progress_channel_id: Some("channel_id".to_string()),
+        store_ack_id_to_recover_address: false,
         expected_error_string: "".to_string(),
     };
     "Happy Path")]
@@ -75,8 +72,9 @@ struct Params {
                 data: None,
             }),
         },
-        pre_reply_in_progress_ibc_transfer: None,
-        store_ack_id_to_in_progress_ibc_transfer: false,
+        pre_reply_in_progress_recover_address: None,
+        pre_reply_in_progress_channel_id: None,
+        store_ack_id_to_recover_address: false,
         expected_error_string: "SubMsgResponse does not contain data".to_string(),
     };
     "Missing Sub Msg Response Data - Expect Error")]
@@ -91,8 +89,9 @@ struct Params {
                 data: Some(b"invalid".into()),
             }),
         },
-        pre_reply_in_progress_ibc_transfer: None,
-        store_ack_id_to_in_progress_ibc_transfer: false,
+        pre_reply_in_progress_recover_address: None,
+        pre_reply_in_progress_channel_id: None,
+        store_ack_id_to_recover_address: false,
         expected_error_string: "failed to decode Protobuf message: buffer underflow".to_string(),
     };
     "Invalid Sub Msg Response Data To Convert To MsgTransferResponse - Expect Error")]
@@ -107,11 +106,29 @@ struct Params {
                 data: Some(MsgTransferResponse {sequence: 5}.encode_to_vec().as_slice().into()),
             }),
         },
-        pre_reply_in_progress_ibc_transfer: None,
-        store_ack_id_to_in_progress_ibc_transfer: false,
-        expected_error_string: "skip::ibc::OsmosisInProgressIbcTransfer not found".to_string(),
+        pre_reply_in_progress_recover_address: None,
+        pre_reply_in_progress_channel_id: Some("channel_id".to_string()),
+        store_ack_id_to_recover_address: false,
+        expected_error_string: "alloc::string::String not found".to_string(),
     };
-    "No In Progress Ibc Transfer To Load - Expect Error")]
+    "No In Progress Recover Address To Load - Expect Error")]
+#[test_case(
+    Params {
+        channel_id: "channel_id".to_string(),
+        sequence_id: 1,
+        reply: Reply {
+            id: 1,
+            result: SubMsgResult::Ok(SubMsgResponse {
+                events: vec![],
+                data: Some(MsgTransferResponse {sequence: 5}.encode_to_vec().as_slice().into()),
+            }),
+        },
+        pre_reply_in_progress_recover_address: Some("recover_address".to_string()),
+        pre_reply_in_progress_channel_id: None,
+        store_ack_id_to_recover_address: false,
+        expected_error_string: "alloc::string::String not found".to_string(),
+    };
+    "No In Progress Channel ID To Load - Expect Error")]
 #[test_case(
     Params {
         channel_id: "channel_id".to_string(),
@@ -123,12 +140,9 @@ struct Params {
                 data: Some(MsgTransferResponse {sequence: 5}.encode_to_vec().as_slice().into()),
             }),
         },
-        pre_reply_in_progress_ibc_transfer: Some(InProgressIBCTransfer {
-            recover_address: "recover_address".to_string(),
-            coin: Coin::new(100, "osmo"),
-            channel_id: "channel_id".to_string(),
-        }),
-        store_ack_id_to_in_progress_ibc_transfer: true,
+        pre_reply_in_progress_recover_address: Some("recover_address".to_string()),
+        pre_reply_in_progress_channel_id: Some("channel_id".to_string()),
+        store_ack_id_to_recover_address: true,
         expected_error_string: "ACK ID already exists for channel ID channel_id and sequence ID 5".to_string(),
     };
     "Ack ID Already Exists - Expect Error")]
@@ -140,12 +154,9 @@ struct Params {
             id: 2,
             result: SubMsgResult::Err("".to_string()),
         },
-        pre_reply_in_progress_ibc_transfer: Some(InProgressIBCTransfer {
-            recover_address: "recover_address".to_string(),
-            coin: Coin::new(100, "osmo"),
-            channel_id: "channel_id".to_string(),
-        }),
-        store_ack_id_to_in_progress_ibc_transfer: false,
+        pre_reply_in_progress_recover_address: Some("recover_address".to_string()),
+        pre_reply_in_progress_channel_id: Some("channel_id".to_string()),
+        store_ack_id_to_recover_address: false,
         expected_error_string: "".to_string(),
     } => panics "internal error: entered unreachable code";
     "SubMsg Incorrect Reply ID - Expect Panic")]
@@ -157,13 +168,10 @@ struct Params {
             id: 1,
             result: SubMsgResult::Err("".to_string()),
         },
-        pre_reply_in_progress_ibc_transfer: Some(InProgressIBCTransfer {
-            recover_address: "recover_address".to_string(),
-            coin: Coin::new(100, "osmo"),
-            channel_id: "channel_id".to_string(),
-        }),
+        pre_reply_in_progress_recover_address: Some("recover_address".to_string()),
+        pre_reply_in_progress_channel_id: Some("channel_id".to_string()),
         expected_error_string: "".to_string(),
-        store_ack_id_to_in_progress_ibc_transfer: false,
+        store_ack_id_to_recover_address: false,
     } => panics "internal error: entered unreachable code";
     "SubMsgResult Error - Expect Panic")]
 fn test_reply(params: Params) -> ContractResult<()> {
@@ -173,18 +181,27 @@ fn test_reply(params: Params) -> ContractResult<()> {
     // Create mock env
     let env = mock_env();
 
-    // Store the in progress ibc transfer to state if it exists
-    if let Some(in_progress_ibc_transfer) = params.pre_reply_in_progress_ibc_transfer.clone() {
-        IN_PROGRESS_IBC_TRANSFER.save(deps.as_mut().storage, &in_progress_ibc_transfer)?;
+    // Store the in progress recover address to state if it exists
+    if let Some(in_progress_recover_address) = params.pre_reply_in_progress_recover_address.clone()
+    {
+        IN_PROGRESS_RECOVER_ADDRESS.save(deps.as_mut().storage, &in_progress_recover_address)?;
+    }
+
+    // Store the in progress channel id to state if it exists
+    if let Some(in_progress_channel_id) = params.pre_reply_in_progress_channel_id.clone() {
+        IN_PROGRESS_CHANNEL_ID.save(deps.as_mut().storage, &in_progress_channel_id)?;
     }
 
     // If the test expects the ack id to in progress ibc transfer map entry to be stored,
     // store it to state
-    if params.store_ack_id_to_in_progress_ibc_transfer {
-        ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER.save(
+    if params.store_ack_id_to_recover_address {
+        ACK_ID_TO_RECOVER_ADDRESS.save(
             deps.as_mut().storage,
             (&params.channel_id, params.sequence_id),
-            &params.pre_reply_in_progress_ibc_transfer.clone().unwrap(),
+            &params
+                .pre_reply_in_progress_recover_address
+                .clone()
+                .unwrap(),
         )?;
     }
 
@@ -202,7 +219,7 @@ fn test_reply(params: Params) -> ContractResult<()> {
             );
 
             // Verify the in progress ibc transfer was removed from storage
-            match IN_PROGRESS_IBC_TRANSFER.load(&deps.storage) {
+            match IN_PROGRESS_RECOVER_ADDRESS.load(&deps.storage) {
                 Ok(in_progress_ibc_transfer) => {
                     panic!(
                         "expected in progress ibc transfer to be removed: {:?}",
@@ -212,16 +229,16 @@ fn test_reply(params: Params) -> ContractResult<()> {
                 Err(err) => assert_eq!(
                     err,
                     StdError::NotFound {
-                        kind: "skip::ibc::OsmosisInProgressIbcTransfer".to_string()
+                        kind: "alloc::string::String".to_string()
                     }
                 ),
             };
 
             // Verify the stored ack id to in progress ibc transfer map entry is correct
             assert_eq!(
-                ACK_ID_TO_IN_PROGRESS_IBC_TRANSFER
+                ACK_ID_TO_RECOVER_ADDRESS
                     .load(&deps.storage, (&params.channel_id, params.sequence_id))?,
-                params.pre_reply_in_progress_ibc_transfer.unwrap()
+                params.pre_reply_in_progress_recover_address.unwrap()
             );
         }
         Err(err) => {

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -115,31 +115,6 @@ impl From<IbcTransfer> for ExecuteMsg {
 // ibc transfer upon receiving a successful sub msg reply.
 pub type AckID<'a> = (&'a str, u64);
 
-// NeutronInProgressIBCTransfer is a struct that is used to store the ibc transfer information
-// upon receiving a successful response from the neutron ibc transfer sub message. Later
-// to be used in the sudo handler to send the coin back to the recover address if the
-// ibc transfer packet acknowledgement is an error or times out. Also used to send the
-// user back the refunded ack fee or timeout fee based on the type of acknowledgement
-#[cw_serde]
-pub struct NeutronInProgressIbcTransfer {
-    pub recover_address: String,
-    pub coin: Coin,
-    pub ack_fee: Vec<Coin>,
-    pub timeout_fee: Vec<Coin>,
-}
-
-// OsmosisInProgressIBCTransfer is a struct that is used to store the ibc transfer information
-// upon receiving a successful sub message reply. Later
-// to be used in the sudo handler to send the coin back to the recover address if the
-// ibc transfer packet acknowledgement is an error or times out. Also used to send the
-// user back the refunded ack fee or timeout fee based on the type of acknowledgement
-#[cw_serde]
-pub struct OsmosisInProgressIbcTransfer {
-    pub recover_address: String,
-    pub coin: Coin,
-    pub channel_id: String,
-}
-
 #[cw_serde]
 pub enum IbcLifecycleComplete {
     IbcAck {

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -33,8 +33,8 @@ pub enum ExecuteMsg {
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum NeutronQueryMsg {
-    #[returns(NeutronInProgressIbcTransfer)]
-    InProgressIbcTransfer {
+    #[returns(String)]
+    InProgressRecoverAddress {
         channel_id: String,
         sequence_id: u64,
     },

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -43,8 +43,8 @@ pub enum NeutronQueryMsg {
 #[cw_serde]
 #[derive(QueryResponses)]
 pub enum OsmosisQueryMsg {
-    #[returns(OsmosisInProgressIbcTransfer)]
-    InProgressIbcTransfer {
+    #[returns(String)]
+    InProgressRecoverAddress {
         channel_id: String,
         sequence_id: u64,
     },


### PR DESCRIPTION
This PR changes the ibc transfer adapter sudo handling from:
- Old: a flow of saving amounts in storage and using those stored amounts to bank send refunds
- New: a flow of querying the contract balance to send refunded funds back to the user (which equates to the refunded fee + failed ibc transfer coin [if it exists] + dust on the contract)

The tradeoff here imo is allowing the user to receive any dust that is on the contract

The thought here is that this runs into less inaccurate storage related issues since we will only ever bank send what we actually have, but is relying on implicit accounting rather than explicit accounting.

This is related to Oak Security Audit Finding #1

Opening this up to serve as a discussion around security.