### PR TITLE
Jl/add swap enum and refund action - STALE

### DIFF
--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -10,9 +10,7 @@ use skip::{
     coins::Coins,
     entry_point::{Action, Affiliate, ExecuteMsg},
     ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcInfo, IbcTransfer},
-    swap::{
-        ExecuteMsg as SwapExecuteMsg, QueryMsg as SwapQueryMsg, SwapExactCoinIn, SwapExactCoinOut,
-    },
+    swap::{ExecuteMsg as SwapExecuteMsg, QueryMsg as SwapQueryMsg, Swap, SwapExactCoinOut},
 };
 
 ///////////////////////////
@@ -27,7 +25,7 @@ pub fn execute_swap_and_action(
     env: Env,
     info: MessageInfo,
     fee_swap: Option<SwapExactCoinOut>,
-    user_swap: SwapExactCoinIn,
+    user_swap: Swap,
     min_coin: Coin,
     timeout_timestamp: u64,
     post_swap_action: Action,
@@ -360,10 +358,16 @@ fn verify_and_create_contract_call_msg(
 // Verifies, creates, and returns the user swap message
 fn verify_and_create_user_swap_msg(
     deps: &DepsMut,
-    user_swap: SwapExactCoinIn,
+    user_swap: Swap,
     remaining_coin_received: Coin,
     min_coin_denom: &str,
 ) -> ContractResult<WasmMsg> {
+    // TODO: Remove panic and handle SwapExactCoinOut later once implemented
+    let user_swap = match user_swap {
+        Swap::SwapExactCoinIn(swap_exact_coin_in) => swap_exact_coin_in,
+        Swap::SwapExactCoinOut(_) => panic!("SwapExactCoinOut not allowed for user swap"),
+    };
+
     // Verify the swap operations are not empty
     let (Some(first_op), Some(last_op)) = (user_swap.operations.first(), user_swap.operations.last()) else {
         return Err(ContractError::UserSwapOperationsEmpty);

--- a/contracts/entry-point/tests/test_execute_post_swap_action.rs
+++ b/contracts/entry-point/tests/test_execute_post_swap_action.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     SubMsg, Timestamp, Uint128, WasmMsg,
 };
 use skip::{
-    entry_point::{Affiliate, ExecuteMsg, PostSwapAction},
+    entry_point::{Action, Affiliate, ExecuteMsg},
     ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcFee, IbcInfo},
 };
 use skip_swap_entry_point::{
@@ -46,7 +46,7 @@ Expect Error
 struct Params {
     caller: String,
     min_coin: Coin,
-    post_swap_action: PostSwapAction,
+    post_swap_action: Action,
     affiliates: Vec<Affiliate>,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
@@ -57,7 +57,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5".to_string(),
         },
         affiliates: vec![],
@@ -78,7 +78,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -127,7 +127,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::ContractCall {
+        post_swap_action: Action::ContractCall {
             contract_address: "contract_call".to_string(),
             msg: to_binary(&"contract_call_msg").unwrap(),
         },
@@ -151,7 +151,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -203,7 +203,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(800_000, "untrn"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -252,7 +252,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "osmo"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "swapper".to_string(),
         },
         affiliates: vec![Affiliate {
@@ -288,7 +288,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "osmo"),
-        post_swap_action: PostSwapAction::ContractCall {
+        post_swap_action: Action::ContractCall {
             contract_address: "contract_call".to_string(),
             msg: to_binary(&"contract_call_msg").unwrap(),
         },
@@ -326,7 +326,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -388,7 +388,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(700_000, "untrn"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -450,7 +450,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(950_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -475,7 +475,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "untrn"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -497,7 +497,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_100_000, "untrn"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "swapper".to_string(),
         },
         affiliates: vec![],
@@ -509,7 +509,7 @@ struct Params {
     Params {
         caller: "unauthorized".to_string(),
         min_coin: Coin::new(1_100_000, "untrn"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "swapper".to_string(),
         },
         affiliates: vec![],
@@ -521,7 +521,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "untrn"),
-        post_swap_action: PostSwapAction::ContractCall {
+        post_swap_action: Action::ContractCall {
             contract_address: "entry_point".to_string(),
             msg: to_binary(&"contract_call_msg").unwrap(),
         },

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
 };
 use cw_utils::PaymentError::{MultipleDenoms, NoFunds};
 use skip::{
-    entry_point::{Affiliate, ExecuteMsg, PostSwapAction},
+    entry_point::{Action, Affiliate, ExecuteMsg},
     ibc::{IbcFee, IbcInfo},
     swap::{ExecuteMsg as SwapExecuteMsg, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
 };
@@ -52,7 +52,7 @@ struct Params {
     user_swap: SwapExactCoinIn,
     min_coin: Coin,
     timeout_timestamp: u64,
-    post_swap_action: PostSwapAction,
+    post_swap_action: Action,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
 }
@@ -77,7 +77,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![
@@ -107,7 +107,7 @@ struct Params {
                     msg: to_binary(&ExecuteMsg::PostSwapAction {
                         min_coin: Coin::new(1_000_000, "osmo"),
                         timeout_timestamp: 101,
-                        post_swap_action: PostSwapAction::BankSend {
+                        post_swap_action: Action::BankSend {
                             to_address: "to_address".to_string(),
                         },
                         affiliates: vec![],
@@ -153,7 +153,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -213,7 +213,7 @@ struct Params {
                     msg: to_binary(&ExecuteMsg::PostSwapAction {
                         min_coin: Coin::new(100_000, "uatom"),
                         timeout_timestamp: 101,
-                        post_swap_action: PostSwapAction::IbcTransfer {
+                        post_swap_action: Action::IbcTransfer {
                             ibc_info: IbcInfo {
                                 source_channel: "channel-0".to_string(),
                                 receiver: "receiver".to_string(),
@@ -270,7 +270,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -330,7 +330,7 @@ struct Params {
                     msg: to_binary(&ExecuteMsg::PostSwapAction {
                         min_coin: Coin::new(100_000, "uatom"),
                         timeout_timestamp: 101,
-                        post_swap_action: PostSwapAction::IbcTransfer {
+                        post_swap_action: Action::IbcTransfer {
                             ibc_info: IbcInfo {
                                 source_channel: "channel-0".to_string(),
                                 receiver: "receiver".to_string(),
@@ -387,7 +387,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -424,7 +424,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -473,7 +473,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -526,7 +526,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -575,7 +575,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -624,7 +624,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -673,7 +673,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -710,7 +710,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -736,7 +736,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -762,7 +762,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -800,7 +800,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -824,7 +824,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -851,7 +851,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -871,7 +871,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -903,7 +903,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -934,7 +934,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 99,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -8,7 +8,7 @@ use cw_utils::PaymentError::{MultipleDenoms, NoFunds};
 use skip::{
     entry_point::{Action, Affiliate, ExecuteMsg},
     ibc::{IbcFee, IbcInfo},
-    swap::{ExecuteMsg as SwapExecuteMsg, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
+    swap::{ExecuteMsg as SwapExecuteMsg, Swap, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
 };
 use skip_swap_entry_point::{error::ContractError, state::SWAP_VENUE_MAP};
 use test_case::test_case;
@@ -49,7 +49,7 @@ Expect Error
 struct Params {
     info_funds: Vec<Coin>,
     fee_swap: Option<SwapExactCoinOut>,
-    user_swap: SwapExactCoinIn,
+    user_swap: Swap,
     min_coin: Coin,
     timeout_timestamp: u64,
     post_swap_action: Action,
@@ -64,17 +64,19 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -141,17 +143,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -259,17 +263,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(800_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(800_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -377,17 +383,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(900_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -414,17 +422,19 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(799_999, "untrn")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(799_999, "untrn")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -464,17 +474,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(100_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(100_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -518,17 +530,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(900_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -568,17 +582,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(900_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -618,17 +634,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(900_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -668,17 +686,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(799_999, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(799_999, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -705,17 +725,19 @@ struct Params {
             Coin::new(1_000_000, "uatom"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(900_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -731,17 +753,19 @@ struct Params {
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(1_000_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(1_000_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -757,17 +781,19 @@ struct Params {
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(1_000_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(1_000_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -796,17 +822,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "atom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "atom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -820,17 +848,19 @@ struct Params {
     Params {
         info_funds: vec![],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -847,17 +877,19 @@ struct Params {
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -873,11 +905,13 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -900,17 +934,19 @@ struct Params {
                 refund_action: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: Some(Coin::new(900_000, "osmo")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -937,11 +973,13 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
-            operations: vec![],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn {
+                swap_venue_name: "swap_venue_name".to_string(),
+                coin_in: None,
+                operations: vec![],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 99,
         post_swap_action: Action::BankSend {

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -138,6 +138,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -255,6 +256,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -372,6 +374,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -458,6 +461,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -511,6 +515,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -560,6 +565,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -609,6 +615,7 @@ struct Params {
                         denom_out: "osmo".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -658,6 +665,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -785,6 +793,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -888,6 +897,7 @@ struct Params {
                 swap_venue_name: "swap_venue_name".to_string(), 
                 coin_out: Coin::new(200_000, "osmo"),
                 operations: vec![],
+                refund_action: None,
             }
         ),
         user_swap: SwapExactCoinIn {

--- a/contracts/networks/osmosis/ibc-transfer/src/contract.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/contract.rs
@@ -103,10 +103,7 @@ fn execute_ibc_transfer(
     )?;
 
     // Save in progress channel id to storage, to be used in sudo handler
-    IN_PROGRESS_CHANNEL_ID.save(
-        deps.storage,
-        &ibc_info.source_channel,
-    )?;
+    IN_PROGRESS_CHANNEL_ID.save(deps.storage, &ibc_info.source_channel)?;
 
     // Verify memo is valid json and add the necessary key/value pair to trigger the ibc hooks callback logic.
     let memo = verify_and_create_memo(ibc_info.memo, env.contract.address.to_string())?;

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{Binary, Coin, Uint128};
 
 use crate::{
     ibc::IbcInfo,
-    swap::{SwapExactCoinIn, SwapExactCoinOut, SwapVenue},
+    swap::{Swap, SwapExactCoinOut, SwapVenue},
 };
 
 ///////////////////
@@ -25,7 +25,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     SwapAndAction {
         fee_swap: Option<SwapExactCoinOut>,
-        user_swap: SwapExactCoinIn,
+        user_swap: Swap,
         min_coin: Coin,
         timeout_timestamp: u64,
         post_swap_action: Action,

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -21,6 +21,7 @@ pub struct InstantiateMsg {
 ///////////////
 
 #[cw_serde]
+#[allow(clippy::large_enum_variant)]
 pub enum ExecuteMsg {
     SwapAndAction {
         fee_swap: Option<SwapExactCoinOut>,

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -27,13 +27,13 @@ pub enum ExecuteMsg {
         user_swap: SwapExactCoinIn,
         min_coin: Coin,
         timeout_timestamp: u64,
-        post_swap_action: PostSwapAction,
+        post_swap_action: Action,
         affiliates: Vec<Affiliate>,
     },
     PostSwapAction {
         min_coin: Coin,
         timeout_timestamp: u64,
-        post_swap_action: PostSwapAction,
+        post_swap_action: Action,
         affiliates: Vec<Affiliate>,
     },
 }
@@ -61,7 +61,7 @@ pub enum QueryMsg {
 ////////////////////
 
 #[cw_serde]
-pub enum PostSwapAction {
+pub enum Action {
     BankSend {
         to_address: String,
     },

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -1,4 +1,7 @@
-use crate::error::SkipError;
+use crate::{
+    entry_point::Action,
+    error::SkipError
+};
 use astroport::{asset::AssetInfo, router::SwapOperation as AstroportSwapOperation};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, BankMsg, Coin, DepsMut, Env, MessageInfo, Response};
@@ -160,6 +163,7 @@ pub struct SwapExactCoinOut {
     pub swap_venue_name: String,
     pub coin_out: Coin,
     pub operations: Vec<SwapOperation>,
+    pub refund_action: Option<Action>,
 }
 
 // Swap object that swaps the given coin in when present. When not present,

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -1,7 +1,4 @@
-use crate::{
-    entry_point::Action,
-    error::SkipError
-};
+use crate::{entry_point::Action, error::SkipError};
 use astroport::{asset::AssetInfo, router::SwapOperation as AstroportSwapOperation};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Addr, BankMsg, Coin, DepsMut, Env, MessageInfo, Response};

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -175,6 +175,12 @@ pub struct SwapExactCoinIn {
     pub operations: Vec<SwapOperation>,
 }
 
+#[cw_serde]
+pub enum Swap {
+    SwapExactCoinIn(SwapExactCoinIn),
+    SwapExactCoinOut(SwapExactCoinOut),
+}
+
 ////////////////////////
 /// COMMON FUNCTIONS ///
 ////////////////////////


### PR DESCRIPTION
This PR:
- Adds an optional `refund_action` param to `SwapExactCoinOut` (to be used if a user swap is swap exact out and needs funds to be sent back)
- Changes `PostSwapAction` type to just `Action` since used in both `post_swap_action` and `refund_action`
- Adds a `Swap` enum with two variants: `SwapExactCoinIn` and `SwapExactCoinOut`
- Changes `user_swap` from type `SwapExactCoinIn` to `Swap` (does not yet handle the SwapExactCoinOut, a todo and panic is put in place right now)