### PR TITLE
♻️ Rename PostSwapAction enum to Action

### DIFF
--- a/contracts/entry-point/tests/test_execute_post_swap_action.rs
+++ b/contracts/entry-point/tests/test_execute_post_swap_action.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::{
     SubMsg, Timestamp, Uint128, WasmMsg,
 };
 use skip::{
-    entry_point::{Affiliate, ExecuteMsg, PostSwapAction},
+    entry_point::{Action, Affiliate, ExecuteMsg},
     ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcFee, IbcInfo},
 };
 use skip_swap_entry_point::{
@@ -46,7 +46,7 @@ Expect Error
 struct Params {
     caller: String,
     min_coin: Coin,
-    post_swap_action: PostSwapAction,
+    post_swap_action: Action,
     affiliates: Vec<Affiliate>,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
@@ -57,7 +57,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5".to_string(),
         },
         affiliates: vec![],
@@ -78,7 +78,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -127,7 +127,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::ContractCall {
+        post_swap_action: Action::ContractCall {
             contract_address: "contract_call".to_string(),
             msg: to_binary(&"contract_call_msg").unwrap(),
         },
@@ -151,7 +151,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_000_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -203,7 +203,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(800_000, "untrn"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -252,7 +252,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "osmo"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "swapper".to_string(),
         },
         affiliates: vec![Affiliate {
@@ -288,7 +288,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "osmo"),
-        post_swap_action: PostSwapAction::ContractCall {
+        post_swap_action: Action::ContractCall {
             contract_address: "contract_call".to_string(),
             msg: to_binary(&"contract_call_msg").unwrap(),
         },
@@ -326,7 +326,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -388,7 +388,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(700_000, "untrn"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -450,7 +450,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(950_000, "osmo"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -475,7 +475,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "untrn"),
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -497,7 +497,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(1_100_000, "untrn"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "swapper".to_string(),
         },
         affiliates: vec![],
@@ -509,7 +509,7 @@ struct Params {
     Params {
         caller: "unauthorized".to_string(),
         min_coin: Coin::new(1_100_000, "untrn"),
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "swapper".to_string(),
         },
         affiliates: vec![],
@@ -521,7 +521,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         min_coin: Coin::new(900_000, "untrn"),
-        post_swap_action: PostSwapAction::ContractCall {
+        post_swap_action: Action::ContractCall {
             contract_address: "entry_point".to_string(),
             msg: to_binary(&"contract_call_msg").unwrap(),
         },

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -6,7 +6,7 @@ use cosmwasm_std::{
 };
 use cw_utils::PaymentError::{MultipleDenoms, NoFunds};
 use skip::{
-    entry_point::{Affiliate, ExecuteMsg, PostSwapAction},
+    entry_point::{Action, Affiliate, ExecuteMsg},
     ibc::{IbcFee, IbcInfo},
     swap::{ExecuteMsg as SwapExecuteMsg, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
 };
@@ -52,7 +52,7 @@ struct Params {
     user_swap: SwapExactCoinIn,
     min_coin: Coin,
     timeout_timestamp: u64,
-    post_swap_action: PostSwapAction,
+    post_swap_action: Action,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
 }
@@ -77,7 +77,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![
@@ -107,7 +107,7 @@ struct Params {
                     msg: to_binary(&ExecuteMsg::PostSwapAction {
                         min_coin: Coin::new(1_000_000, "osmo"),
                         timeout_timestamp: 101,
-                        post_swap_action: PostSwapAction::BankSend {
+                        post_swap_action: Action::BankSend {
                             to_address: "to_address".to_string(),
                         },
                         affiliates: vec![],
@@ -153,7 +153,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -213,7 +213,7 @@ struct Params {
                     msg: to_binary(&ExecuteMsg::PostSwapAction {
                         min_coin: Coin::new(100_000, "uatom"),
                         timeout_timestamp: 101,
-                        post_swap_action: PostSwapAction::IbcTransfer {
+                        post_swap_action: Action::IbcTransfer {
                             ibc_info: IbcInfo {
                                 source_channel: "channel-0".to_string(),
                                 receiver: "receiver".to_string(),
@@ -270,7 +270,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -330,7 +330,7 @@ struct Params {
                     msg: to_binary(&ExecuteMsg::PostSwapAction {
                         min_coin: Coin::new(100_000, "uatom"),
                         timeout_timestamp: 101,
-                        post_swap_action: PostSwapAction::IbcTransfer {
+                        post_swap_action: Action::IbcTransfer {
                             ibc_info: IbcInfo {
                                 source_channel: "channel-0".to_string(),
                                 receiver: "receiver".to_string(),
@@ -387,7 +387,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -424,7 +424,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -473,7 +473,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -526,7 +526,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -575,7 +575,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -624,7 +624,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -673,7 +673,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -710,7 +710,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -736,7 +736,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -762,7 +762,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -800,7 +800,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -824,7 +824,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -851,7 +851,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -871,7 +871,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],
@@ -903,7 +903,7 @@ struct Params {
         },
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
-        post_swap_action: PostSwapAction::IbcTransfer {
+        post_swap_action: Action::IbcTransfer {
             ibc_info: IbcInfo {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
@@ -934,7 +934,7 @@ struct Params {
         },
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 99,
-        post_swap_action: PostSwapAction::BankSend {
+        post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
         },
         expected_messages: vec![],

--- a/contracts/networks/osmosis/ibc-transfer/src/contract.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/contract.rs
@@ -103,10 +103,7 @@ fn execute_ibc_transfer(
     )?;
 
     // Save in progress channel id to storage, to be used in sudo handler
-    IN_PROGRESS_CHANNEL_ID.save(
-        deps.storage,
-        &ibc_info.source_channel,
-    )?;
+    IN_PROGRESS_CHANNEL_ID.save(deps.storage, &ibc_info.source_channel)?;
 
     // Verify memo is valid json and add the necessary key/value pair to trigger the ibc hooks callback logic.
     let memo = verify_and_create_memo(ibc_info.memo, env.contract.address.to_string())?;

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -27,13 +27,13 @@ pub enum ExecuteMsg {
         user_swap: SwapExactCoinIn,
         min_coin: Coin,
         timeout_timestamp: u64,
-        post_swap_action: PostSwapAction,
+        post_swap_action: Action,
         affiliates: Vec<Affiliate>,
     },
     PostSwapAction {
         min_coin: Coin,
         timeout_timestamp: u64,
-        post_swap_action: PostSwapAction,
+        post_swap_action: Action,
         affiliates: Vec<Affiliate>,
     },
 }
@@ -61,7 +61,7 @@ pub enum QueryMsg {
 ////////////////////
 
 #[cw_serde]
-pub enum PostSwapAction {
+pub enum Action {
     BankSend {
         to_address: String,
     },


### PR DESCRIPTION
This PR renames PostSwapAction enum to Action since the var name is `post_swap_action` and captures when the Action type is used. Also allows future places in the contract to use the Action enum.