### PR TITLE
✨ Add optional refund address to SwapExactCoinOut

### DIFF
--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -138,6 +138,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -255,6 +256,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -372,6 +374,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -458,6 +461,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -511,6 +515,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -560,6 +565,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -609,6 +615,7 @@ struct Params {
                         denom_out: "osmo".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -658,6 +665,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -785,6 +793,7 @@ struct Params {
                         denom_out: "untrn".to_string(),
                     }
                 ],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {
@@ -888,6 +897,7 @@ struct Params {
                 swap_venue_name: "swap_venue_name".to_string(), 
                 coin_out: Coin::new(200_000, "osmo"),
                 operations: vec![],
+                refund_address: None,
             }
         ),
         user_swap: SwapExactCoinIn {

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -21,6 +21,7 @@ pub struct InstantiateMsg {
 ///////////////
 
 #[cw_serde]
+#[allow(clippy::large_enum_variant)]
 pub enum ExecuteMsg {
     SwapAndAction {
         fee_swap: Option<SwapExactCoinOut>,

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -160,6 +160,7 @@ pub struct SwapExactCoinOut {
     pub swap_venue_name: String,
     pub coin_out: Coin,
     pub operations: Vec<SwapOperation>,
+    pub refund_address: Option<String>,
 }
 
 // Swap object that swaps the given coin in when present. When not present,


### PR DESCRIPTION
This PR adds an optional refund address to `SwapExactCoinOut`, which will be later used when supporting the `user_swap` being a `SwapExactCoinOut` and wanting to bank send leftover assets to the user.