### PR TITLE
⚡️ Derive user swap coin in from remaining coin received only

### DIFF
--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -44,16 +44,6 @@ pub enum ContractError {
     #[error("Fee Swap Coin Out Greater Than IBC Fee")]
     FeeSwapCoinOutGreaterThanIbcFee,
 
-    /////////////////
-    /// USER SWAP ///
-    /////////////////
-
-    #[error("User Swap Coin In Denom Differs From Coin Sent To Contract")]
-    UserSwapCoinInDenomMismatch,
-
-    #[error("User Swap Coin In Amount Is Not Equal To The Remaining Coin Received")]
-    UserSwapCoinInNotEqualToRemainingReceived,
-
     ////////////////////////
     /// POST SWAP ACTION ///
     ////////////////////////

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -34,9 +34,7 @@ Expect Error
     - Fee Swap Coin Out Greater Than Ibc Fee Requires
 
     // User Swap
-    - User Swap Specified Coin More Than Remaining Coin Sent To Contract After Fee Swap
-    - User Swap Denom In Is Not The Same As Coin Sent To Contract
-    - User Swap Denom In Is Not The Same As First Swap Operation Denom In
+    - User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
     - User Swap Last Swap Operation Denom Out Is Not The Same As Min Coin Out Denom
 
     // Invalid Coins Sent To Contract
@@ -69,7 +67,6 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![
                 SwapOperation {
                     pool: "pool".to_string(),
@@ -146,7 +143,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -264,7 +260,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(800_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -364,93 +359,6 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![
-            Coin::new(1_000_000, "osmo"),
-        ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
-        min_coin: Coin::new(100_000, "uatom"),
-        timeout_timestamp: 101,
-        post_swap_action: Action::IbcTransfer {
-            ibc_info: IbcInfo {
-                source_channel: "channel-0".to_string(),
-                receiver: "receiver".to_string(),
-                memo: "".to_string(),
-                fee: IbcFee {
-                    recv_fee: vec![],
-                    ack_fee: vec![Coin::new(100_000, "untrn")],
-                    timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
-                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
-                    .to_string(),
-            },
-        },
-        expected_messages: vec![],
-        expected_error: Some(ContractError::UserSwapCoinInNotEqualToRemainingReceived),
-    };
-    "User Swap Specified Coin More Than Remaining Coin Sent To Contract After Fee Swap - Expect Error")]
-#[test_case(
-    Params {
-        info_funds: vec![
-            Coin::new(1_000_000, "untrn"),
-        ],
-        fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(799_999, "untrn")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
-        min_coin: Coin::new(100_000, "uatom"),
-        timeout_timestamp: 101,
-        post_swap_action: Action::IbcTransfer {
-            ibc_info: IbcInfo {
-                source_channel: "channel-0".to_string(),
-                receiver: "receiver".to_string(),
-                memo: "".to_string(),
-                fee: IbcFee {
-                    recv_fee: vec![],
-                    ack_fee: vec![Coin::new(100_000, "untrn")],
-                    timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
-                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
-                    .to_string(),
-            },
-        },
-        expected_messages: vec![],
-        expected_error: Some(ContractError::UserSwapCoinInNotEqualToRemainingReceived),
-    };
-    "User Swap Specified Coin Less Than Remaining Coin Left To Swap - Expect Error")]
-#[test_case(
-    Params {
-        info_funds: vec![
             Coin::new(100_000, "osmo"),
         ],
         fee_swap: Some(
@@ -469,7 +377,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(100_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -523,7 +430,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -573,7 +479,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -623,7 +528,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -673,7 +577,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(799_999, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -705,38 +608,11 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![
-            Coin::new(1_000_000, "uatom"),
-        ],
-        fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
-        min_coin: Coin::new(100_000, "uatom"),
-        timeout_timestamp: 101,
-        post_swap_action: Action::BankSend {
-            to_address: "to_address".to_string(),
-        },
-        expected_messages: vec![],
-        expected_error: Some(ContractError::UserSwapCoinInDenomMismatch),
-    };
-    "User Swap Denom In Is Not The Same As Coin Sent To Contract - Expect Error")]
-#[test_case(
-    Params {
-        info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(1_000_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -753,7 +629,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::Skip(SwapOperationsCoinInDenomMismatch)),
     };
-    "User Swap Denom In Is Not The Same As First Swap Operation Denom In - Expect Error")]
+    "User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -762,7 +638,6 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(1_000_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -801,7 +676,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -825,7 +699,6 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![
                 SwapOperation {
                     pool: "pool".to_string(),
@@ -852,7 +725,6 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![
                 SwapOperation {
                     pool: "pool".to_string(),
@@ -878,7 +750,6 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![],
         },
         min_coin: Coin::new(1_000_000, "osmo"),
@@ -905,7 +776,6 @@ struct Params {
         ),
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: Some(Coin::new(900_000, "osmo")),
             operations: vec![
                 SwapOperation {
                     pool: "pool_2".to_string(),
@@ -942,7 +812,6 @@ struct Params {
         fee_swap: None,
         user_swap: SwapExactCoinIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            coin_in: None,
             operations: vec![],
         },
         min_coin: Coin::new(1_000_000, "osmo"),

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -163,12 +163,11 @@ pub struct SwapExactCoinOut {
     pub refund_address: Option<String>,
 }
 
-// Swap object that swaps the given coin in when present. When not present,
-// swaps the remaining coin recevied from the contract call minus fee swap (if present)
+// Swap object that swaps the remaining coin recevied
+// from the contract call minus fee swap (if present)
 #[cw_serde]
 pub struct SwapExactCoinIn {
     pub swap_venue_name: String,
-    pub coin_in: Option<Coin>,
     pub operations: Vec<SwapOperation>,
 }
 


### PR DESCRIPTION
## Background
- When the contract was originally developed, it did not have enforcement that a user would not be allowed to leave funds on contract by accident if they input a `coin_in` in `user_swap` that was less than the `remaining_coin_received` on contract.
- This was changed to be enforced after the audit findings.
- After implementing the audit changes, the logic enforced that the `coin_in` in `user_swap` was the exact same as the `remaining_coin_received`, otherwise it errors. So it no longer makes sense to accept a `coin_in` parameter if all it does is open up a vector for a user error that errors the transaction. 

## This PR
1. Removes the `coin_in` field in the `SwapExactCoinIn` type
2. Removes logic in the entry point contract that used the `coin_in` field, instead just using `remaining_coin_received`
3. Updates tests