### PR TITLE
⚡️ Change IBC Fee to be Optional

### DIFF
--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -35,8 +35,8 @@ pub enum ContractError {
     /// FEE SWAP ///
     ////////////////
 
-    #[error("Fee Swap Not Allowed: Post Swap Action Is Not An IBC Transfer")]
-    FeeSwapNotAllowed,
+    #[error("Fee Swap Not Allowed: No IBC Fees Provided")]
+    FeeSwapWithoutIbcFees,
 
     #[error("Fee Swap Coin In Denom Differs From Coin Sent To Contract")]
     FeeSwapCoinInDenomMismatch,

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -240,7 +240,7 @@ fn verify_and_create_fee_swap_msg(
 ) -> ContractResult<WasmMsg> {
     // Error if the ibc fees is empty since a fee swap is not needed
     if ibc_fees.is_empty() {
-        return Err(ContractError::FeeSwapNotAllowed);
+        return Err(ContractError::FeeSwapWithoutIbcFees);
     }
 
     // Validate swap operations

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -51,7 +51,7 @@ pub fn execute_swap_and_action(
     // Get the ibc_info from the post swap action if the post swap action
     // is an IBC transfer, otherwise set it to None
     let ibc_fees = match &post_swap_action {
-        Action::IbcTransfer { ibc_info } => ibc_info.fee.clone().try_into()?,
+        Action::IbcTransfer { ibc_info } => ibc_info.fee.clone().unwrap_or_default().try_into()?,
         _ => Coins::default(),
     };
 
@@ -373,7 +373,7 @@ fn verify_and_create_ibc_transfer_adapter_msg(
     deps.api.addr_validate(&ibc_info.recover_address)?;
 
     // Create the ibc_fees map from the given recv_fee, ack_fee, and timeout_fee
-    let ibc_fees_map: Coins = ibc_info.fee.clone().try_into()?;
+    let ibc_fees_map: Coins = ibc_info.fee.clone().unwrap_or_default().try_into()?;
 
     // Get the amount of the IBC fee payment that matches
     // the denom of the ibc transfer out coin.

--- a/contracts/entry-point/tests/test_execute_post_swap_action.rs
+++ b/contracts/entry-point/tests/test_execute_post_swap_action.rs
@@ -83,11 +83,7 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
-                    recv_fee: vec![],
-                    ack_fee: vec![],
-                    timeout_fee: vec![],
-                },
+                fee: None,
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
@@ -102,11 +98,7 @@ struct Params {
                         source_channel: "channel-0".to_string(),
                         receiver: "receiver".to_string(),
                         memo: "".to_string(),
-                        fee: IbcFee {
-                            recv_fee: vec![],
-                            ack_fee: vec![],
-                            timeout_fee: vec![],
-                        },
+                        fee: None,
                         recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                             .to_string(),
                     },
@@ -156,11 +148,11 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
+                fee: Some(IbcFee {
                     recv_fee: vec![],
                     ack_fee: vec![Coin::new(100_000, "untrn")],
                     timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
+                }),
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
@@ -175,11 +167,11 @@ struct Params {
                         source_channel: "channel-0".to_string(),
                         receiver: "receiver".to_string(),
                         memo: "".to_string(),
-                        fee: IbcFee {
+                        fee: Some(IbcFee {
                             recv_fee: vec![],
                             ack_fee: vec![Coin::new(100_000, "untrn")],
                             timeout_fee: vec![Coin::new(100_000, "untrn")],
-                        },
+                        }),
                         recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                             .to_string(),
                     },
@@ -208,11 +200,11 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
+                fee: Some(IbcFee {
                     recv_fee: vec![],
                     ack_fee: vec![Coin::new(100_000, "untrn")],
                     timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
+                }),
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
@@ -227,11 +219,11 @@ struct Params {
                         source_channel: "channel-0".to_string(),
                         receiver: "receiver".to_string(),
                         memo: "".to_string(),
-                        fee: IbcFee {
+                        fee: Some(IbcFee {
                             recv_fee: vec![],
                             ack_fee: vec![Coin::new(100_000, "untrn")],
                             timeout_fee: vec![Coin::new(100_000, "untrn")],
-                        },
+                        }),
                         recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                             .to_string(),
                     },
@@ -331,11 +323,11 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
+                fee: Some(IbcFee {
                     recv_fee: vec![],
                     ack_fee: vec![Coin::new(100_000, "untrn")],
                     timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
+                }),
                 recover_address: "recover".to_string(),
             },
         },
@@ -363,11 +355,11 @@ struct Params {
                             source_channel: "channel-0".to_string(),
                             receiver: "receiver".to_string(),
                             memo: "".to_string(),
-                            fee: IbcFee {
+                            fee: Some(IbcFee {
                                 recv_fee: vec![],
                                 ack_fee: vec![Coin::new(100_000, "untrn")],
                                 timeout_fee: vec![Coin::new(100_000, "untrn")],
-                            },
+                            }),
                             recover_address: "recover".to_string(),
                         },
                         coin: Coin::new(900_000, "osmo"),
@@ -393,11 +385,11 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
+                fee: Some(IbcFee {
                     recv_fee: vec![],
                     ack_fee: vec![Coin::new(100_000, "untrn")],
                     timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
+                }),
                 recover_address: "recover".to_string(),
             },
         },
@@ -425,11 +417,11 @@ struct Params {
                             source_channel: "channel-0".to_string(),
                             receiver: "receiver".to_string(),
                             memo: "".to_string(),
-                            fee: IbcFee {
+                            fee: Some(IbcFee {
                                 recv_fee: vec![],
                                 ack_fee: vec![Coin::new(100_000, "untrn")],
                                 timeout_fee: vec![Coin::new(100_000, "untrn")],
-                            },
+                            }),
                             recover_address: "recover".to_string(),
                         },
                         coin: Coin::new(700_000, "untrn"),
@@ -455,11 +447,11 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
+                fee: Some(IbcFee {
                     recv_fee: vec![],
                     ack_fee: vec![Coin::new(100_000, "untrn")],
                     timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
+                }),
                 recover_address: "recover".to_string(),
             },
         },
@@ -480,11 +472,11 @@ struct Params {
                 source_channel: "channel-0".to_string(),
                 receiver: "receiver".to_string(),
                 memo: "".to_string(),
-                fee: IbcFee {
+                fee: Some(IbcFee {
                     recv_fee: vec![],
                     ack_fee: vec![Coin::new(100_000, "untrn")],
                     timeout_fee: vec![Coin::new(100_000, "untrn")],
-                },
+                }),
                 recover_address: "recover".to_string(),
             },
         },

--- a/contracts/networks/neutron/ibc-transfer/src/contract.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/contract.rs
@@ -82,6 +82,12 @@ fn execute_ibc_transfer(
         return Err(ContractError::Unauthorized);
     }
 
+    // Error if ibc_info.fee is not Some since they are required on Neutron.
+    let ibc_fee = match ibc_info.fee {
+        Some(fee) => fee,
+        None => return Err(ContractError::IbcFeesRequired),
+    };
+
     // Create neutron ibc transfer message
     let msg = MsgTransfer {
         source_port: "transfer".to_string(),
@@ -92,7 +98,7 @@ fn execute_ibc_transfer(
         timeout_height: None,
         timeout_timestamp,
         memo: ibc_info.memo,
-        fee: Some(ibc_info.fee.clone().into()),
+        fee: Some(ibc_fee.into()),
     };
 
     // Save in progress recover address to storage, to be used in sudo handler

--- a/contracts/networks/neutron/ibc-transfer/src/error.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/error.rs
@@ -17,6 +17,9 @@ pub enum ContractError {
     #[error("Unauthorized")]
     Unauthorized,
 
+    #[error("IBC fees are required")]
+    IbcFeesRequired,
+
     #[error("SubMsgResponse does not contain data")]
     MissingResponseData,
 

--- a/contracts/networks/neutron/ibc-transfer/tests/test_execute_ibc_transfer.rs
+++ b/contracts/networks/neutron/ibc-transfer/tests/test_execute_ibc_transfer.rs
@@ -21,6 +21,7 @@ Expect Response
 
 Expect Error
     - Unauthorized Caller (Only the stored entry point contract can call this function)
+    - No IBC Fees Provided (IBC fees are required for Osmosis)
  */
 
 // Define test parameters
@@ -43,14 +44,14 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
+            fee: Some(IbcFee {
                 recv_fee: vec![],
                 ack_fee: vec![Coin {
                     denom: "ntrn".to_string(),
                     amount: Uint128::new(10),
                 }],
                 timeout_fee: vec![],
-            },
+            }),
             memo: "memo".to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -93,14 +94,14 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
+            fee: Some(IbcFee {
                 recv_fee: vec![],
                 ack_fee: vec![Coin {
                     denom: "ntrn".to_string(),
                     amount: Uint128::new(10),
                 }],
                 timeout_fee: vec![],
-            },
+            }),
             memo: "memo".to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -109,6 +110,23 @@ struct Params {
         expected_error_string: "Unauthorized".to_string(),
     };
     "Unauthorized Caller - Expect Error")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        ibc_adapter_contract_address: Addr::unchecked("ibc_transfer".to_string()),
+        coin: Coin::new(100, "osmo"),
+        ibc_info: IbcInfo {
+            source_channel: "source_channel".to_string(),
+            receiver: "receiver".to_string(),
+            fee: None,
+            memo: "memo".to_string(),
+            recover_address: "recover_address".to_string(),
+        },
+        timeout_timestamp: 100,
+        expected_messages: vec![],
+        expected_error_string: "IBC fees are required".to_string(),
+    };
+    "No IBC Fees Provided - Expect Error")]
 fn test_execute_ibc_transfer(params: Params) -> ContractResult<()> {
     // Create mock dependencies
     let mut deps = mock_dependencies();

--- a/contracts/networks/osmosis/ibc-transfer/src/contract.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/contract.rs
@@ -6,15 +6,15 @@ use crate::{
     },
 };
 use cosmwasm_std::{
-    entry_point, to_binary, BankMsg, Binary, Coin, Coins, CosmosMsg, Deps, DepsMut, Env,
-    MessageInfo, Reply, Response, SubMsg, SubMsgResult,
+    entry_point, to_binary, BankMsg, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo,
+    Reply, Response, SubMsg, SubMsgResult,
 };
 use ibc_proto::ibc::applications::transfer::v1::{MsgTransfer, MsgTransferResponse};
 use prost::Message;
 use serde_cw_value::Value;
 use skip::{
     ibc::{
-        AckID, ExecuteMsg, IbcFee, IbcInfo, IbcLifecycleComplete, InstantiateMsg,
+        AckID, ExecuteMsg, IbcInfo, IbcLifecycleComplete, InstantiateMsg,
         OsmosisQueryMsg as QueryMsg,
     },
     proto_coin::ProtoCoin,
@@ -89,9 +89,8 @@ fn execute_ibc_transfer(
         return Err(ContractError::Unauthorized);
     }
 
-    // Error if the ibc_fees specified are not empty since
-    // osmosis ibc transfers do not support fees.
-    if !<IbcFee as TryInto<Coins>>::try_into(ibc_info.fee)?.is_empty() {
+    // Error if ibc_info.fee is not None since Osmosis does not support fees
+    if ibc_info.fee.is_some() {
         return Err(ContractError::IbcFeesNotSupported);
     }
 

--- a/contracts/networks/osmosis/ibc-transfer/tests/test_execute_ibc_transfer.rs
+++ b/contracts/networks/osmosis/ibc-transfer/tests/test_execute_ibc_transfer.rs
@@ -49,11 +49,7 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
-                recv_fee: vec![],
-                ack_fee: vec![],
-                timeout_fee: vec![],
-            },
+            fee: None,
             memo: "".to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -92,11 +88,7 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
-                recv_fee: vec![],
-                ack_fee: vec![],
-                timeout_fee: vec![],
-            },
+            fee: None,
             memo: r#"{"ibc_callback":"random_address"}"#.to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -135,11 +127,7 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
-                recv_fee: vec![],
-                ack_fee: vec![],
-                timeout_fee: vec![],
-            },
+            fee: None,
             memo: r#"{"pfm":"example_value","wasm":"example_contract"}"#.to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -178,11 +166,7 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
-                recv_fee: vec![],
-                ack_fee: vec![],
-                timeout_fee: vec![],
-            },
+            fee: None,
             memo: "{invalid}".to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -199,13 +183,13 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
+            fee: Some(IbcFee {
                 recv_fee: vec![
                     Coin::new(100, "atom"),
                 ],
                 ack_fee: vec![],
                 timeout_fee: vec![],
-            },
+            }),
             memo: "{}".to_string(),
             recover_address: "recover_address".to_string(),
         },
@@ -222,11 +206,7 @@ struct Params {
         ibc_info: IbcInfo {
             source_channel: "source_channel".to_string(),
             receiver: "receiver".to_string(),
-            fee: IbcFee {
-                recv_fee: vec![],
-                ack_fee: vec![],
-                timeout_fee: vec![],
-            },
+            fee: None,
             memo: "{}".to_string(),
             recover_address: "recover_address".to_string(),
         },

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -55,6 +55,7 @@ pub enum OsmosisQueryMsg {
 ////////////////////
 
 #[cw_serde]
+#[derive(Default)]
 pub struct IbcFee {
     pub recv_fee: Vec<Coin>,
     pub ack_fee: Vec<Coin>,

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -104,7 +104,7 @@ impl TryFrom<IbcFee> for Coins {
 pub struct IbcInfo {
     pub source_channel: String,
     pub receiver: String,
-    pub fee: IbcFee,
+    pub fee: Option<IbcFee>,
     pub memo: String,
     pub recover_address: String,
 }


### PR DESCRIPTION
This PR:
1. changes `IbcInfo.Fee` to be of type `Option<IbcFee>` instead of a required field, since it is not required for all chains (Osmosis being an example of a chain that doesn't use ibc fees).
2. Updates the adapter and entry point contracts accordingly to handle the Some or None cases
3. Updates the tests accordingly, adding extra tests to check the logical paths from handling the Some or None cases

This makes it more explicit and doesn't have us checking each vector to see if ibc_fees is present or not.