### PR TITLE
⚡️ Derive Fee Swap Coin Out From IBC Fees Provided

### DIFF
--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -31,6 +31,9 @@ pub enum ContractError {
     #[error("Duplicate Swap Venue Name Provided")]
     DuplicateSwapVenueName,
 
+    #[error("IBC fee denom differs from coin received without a fee swap to convert")]
+    IBCFeeDenomDiffersFromCoinReceived,
+
     ////////////////
     /// FEE SWAP ///
     ////////////////
@@ -38,11 +41,11 @@ pub enum ContractError {
     #[error("Fee Swap Not Allowed: No IBC Fees Provided")]
     FeeSwapWithoutIbcFees,
 
+    #[error("Fee Swap Not Allowed: No Post Swap Action IBC Transfer")]
+    FeeSwapWithoutIbcTransfer,
+
     #[error("Fee Swap Coin In Denom Differs From Coin Sent To Contract")]
     FeeSwapCoinInDenomMismatch,
-
-    #[error("Fee Swap Coin Out Greater Than IBC Fee")]
-    FeeSwapCoinOutGreaterThanIbcFee,
 
     ////////////////////////
     /// POST SWAP ACTION ///

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -27,12 +27,12 @@ Expect Response
 
 Expect Error
     // Fee Swap
-    - Fee Swap Necessary Coin More Than Sent To Contract
-    - Fee Swap Required Denom In Not The Same As Coin Sent To Contract
-    - Fee Swap Required Denom In Not The Same As First Swap Operation Denom In
-    - Fee Swap Coin Out Denom Is Not The Same As Last Swap Operation Denom Out
-    - Fee Swap And User Swap Without IBC Transfer
-    - Fee Swap And User Swap Without IBC Fees
+    - Fee Swap Coin In Amount More Than Remaining Coin Received Amount
+    - Fee Swap Coin In Denom In Not The Same As Remaining Coin Received Denom
+    - Fee Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
+    - Fee Swap Last Swap Operation Denom Out Is Not The Same As IBC Fee Coin Denom
+    - Fee Swap Without IBC Transfer
+    - Fee Swap With IBC Trnasfer But Without IBC Fees
 
     // User Swap
     - User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
@@ -455,7 +455,7 @@ struct Params {
             operand2: "200000".to_string(),
         })),
     };
-    "Fee Swap Necessary Coin More Than Sent To Contract - Expect Error")]
+    "Fee Swap Coin In Amount More Than Remaining Coin Received Amount- Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -503,7 +503,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::FeeSwapCoinInDenomMismatch),
     };
-    "Fee Swap Required Denom In Not The Same As Coin Sent To Contract - Expect Error")]
+    "Fee Swap Coin In Denom In Not The Same As Remaining Coin Received Denom - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -551,7 +551,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::Skip(SwapOperationsCoinInDenomMismatch)),
     };
-    "Fee Swap Required Denom In Not The Same As First Swap Operation Denom In - Expect Error")]
+    "Fee Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -599,7 +599,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::Skip(SwapOperationsCoinOutDenomMismatch)),
     };
-    "Fee Swap Coin Out Denom Is Not The Same As Last Swap Operation Denom Out - Expect Error")]
+    "Fee Swap Last Swap Operation Denom Out Is Not The Same As IBC Fee Coin Denom- Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -686,7 +686,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::FeeSwapWithoutIbcTransfer),
     };
-    "Fee Swap And User Swap Without IBC Transfer - Expect Error")]
+    "Fee Swap Without IBC Transfer - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -730,7 +730,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::FeeSwapWithoutIbcFees),
     };
-    "Fee Swap And User Swap Without IBC Fees - Expect Error")]
+    "Fee Swap With IBC Trnasfer But Without IBC Fees - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![],

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -33,12 +33,11 @@ Expect Error
     - Fee Swap Last Swap Operation Denom Out Is Not The Same As IBC Fee Coin Denom
     - Fee Swap Without IBC Transfer
     - Fee Swap With IBC Trnasfer But Without IBC Fees
-    - Fee Swap With IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified
-    - Fee Swap With IBC Transfer With IBC Fees But No IBC Fee Coins Specified
 
     // User Swap
     - User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
     - User Swap Last Swap Operation Denom Out Is Not The Same As Min Coin Out Denom
+    - User Swap With IBC Transfer With IBC Fees But IBC Fee Coin Denom Is Not The Same As Remaining Coin Received Denom
 
     // Invalid Coins Sent To Contract
     - No Coins Sent To Contract
@@ -50,6 +49,10 @@ Expect Error
 
     // Timeout
     - Current Block Time Greater Than Timeout Timestamp
+
+    // IBC Transfer
+    - IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified
+    - IBC Transfer With IBC Fees But No IBC Fee Coins Specified
  */
 
 // Define test parameters
@@ -630,6 +633,42 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![
+            Coin::new(1_000_000, "untrn"),
+        ],
+        fee_swap: None,
+        user_swap: SwapExactCoinIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            operations: vec![
+                SwapOperation {
+                    pool: "pool".to_string(),
+                    denom_in: "untrn".to_string(),
+                    denom_out: "osmo".to_string(),
+                }
+            ],
+        },
+        min_coin: Coin::new(800_000, "osmo"),
+        timeout_timestamp: 101,
+        post_swap_action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: Some(IbcFee {
+                    recv_fee: vec![],
+                    ack_fee: vec![Coin::new(100_000, "uatom")],
+                    timeout_fee: vec![Coin::new(100_000, "uatom")],
+                }),
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+        },
+        expected_messages: vec![],
+        expected_error: Some(ContractError::IBCFeeDenomDiffersFromCoinReceived),
+    };
+    "User Swap With IBC Transfer With IBC Fees But IBC Fee Coin Denom Is Not The Same As Remaining Coin Received Denom - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
@@ -780,7 +819,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::Skip(IbcFeesNotOneCoin)),
     };
-    "Fee Swap With IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified - Expect Error")]
+    "IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -828,7 +867,7 @@ struct Params {
         expected_messages: vec![],
         expected_error: Some(ContractError::Skip(IbcFeesNotOneCoin)),
     };
-    "Fee Swap With IBC Transfer With IBC Fees But No IBC Fee Coins Specified - Expect Error")]
+    "IBC Transfer With IBC Fees But No IBC Fee Coins Specified - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![],

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -31,8 +31,8 @@ Expect Error
     - Fee Swap Required Denom In Not The Same As Coin Sent To Contract
     - Fee Swap Required Denom In Not The Same As First Swap Operation Denom In
     - Fee Swap Coin Out Denom Is Not The Same As Last Swap Operation Denom Out
+    - Fee Swap And User Swap Without IBC Transfer
     - Fee Swap And User Swap Without IBC Fees
-    - Fee Swap Coin Out Greater Than Ibc Fee Requires
 
     // User Swap
     - User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
@@ -296,7 +296,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
                 operations: vec![
                     SwapOperation {
                         pool: "pool".to_string(),
@@ -413,7 +412,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
                 operations: vec![
                     SwapOperation {
                         pool: "pool".to_string(),
@@ -466,7 +464,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
                 operations: vec![
                     SwapOperation {
                         pool: "pool".to_string(),
@@ -515,7 +512,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
                 operations: vec![
                     SwapOperation {
                         pool: "pool".to_string(),
@@ -564,7 +560,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
                 operations: vec![
                     SwapOperation {
                         pool: "pool".to_string(),
@@ -605,55 +600,6 @@ struct Params {
         expected_error: Some(ContractError::Skip(SwapOperationsCoinOutDenomMismatch)),
     };
     "Fee Swap Coin Out Denom Is Not The Same As Last Swap Operation Denom Out - Expect Error")]
-#[test_case(
-    Params {
-        info_funds: vec![
-            Coin::new(1_000_000, "osmo"),
-        ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_001, "untrn"),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
-        min_coin: Coin::new(100_000, "uatom"),
-        timeout_timestamp: 101,
-        post_swap_action: Action::IbcTransfer {
-            ibc_info: IbcInfo {
-                source_channel: "channel-0".to_string(),
-                receiver: "receiver".to_string(),
-                memo: "".to_string(),
-                fee: Some(IbcFee {
-                    recv_fee: vec![],
-                    ack_fee: vec![Coin::new(100_000, "untrn")],
-                    timeout_fee: vec![Coin::new(100_000, "untrn")],
-                }),
-                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
-                    .to_string(),
-            },
-        },
-        expected_messages: vec![],
-        expected_error: Some(ContractError::FeeSwapCoinOutGreaterThanIbcFee),
-    };
-    "Fee Swap Coin Out Greater Than Ibc Fee Requires")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -712,7 +658,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "untrn"),
                 operations: vec![
                     SwapOperation {
                         pool: "pool".to_string(),
@@ -737,6 +682,50 @@ struct Params {
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
             to_address: "to_address".to_string(),
+        },
+        expected_messages: vec![],
+        expected_error: Some(ContractError::FeeSwapWithoutIbcTransfer),
+    };
+    "Fee Swap And User Swap Without IBC Transfer - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![
+            Coin::new(1_000_000, "osmo"),
+        ],
+        fee_swap: Some(
+            SwapExactCoinOut {
+                swap_venue_name: "swap_venue_name".to_string(), 
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "untrn".to_string(),
+                    }
+                ],
+                refund_address: None,
+            }
+        ),
+        user_swap: SwapExactCoinIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            operations: vec![
+                SwapOperation {
+                    pool: "pool_2".to_string(),
+                    denom_in: "osmo".to_string(),
+                    denom_out: "atom".to_string(),
+                }
+            ],
+        },
+        min_coin: Coin::new(100_000, "atom"),
+        timeout_timestamp: 101,
+        post_swap_action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: None,
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
         },
         expected_messages: vec![],
         expected_error: Some(ContractError::FeeSwapWithoutIbcFees),
@@ -818,7 +807,6 @@ struct Params {
         fee_swap: Some(
             SwapExactCoinOut {
                 swap_venue_name: "swap_venue_name".to_string(), 
-                coin_out: Coin::new(200_000, "osmo"),
                 operations: vec![],
                 refund_address: None,
             }

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -8,7 +8,7 @@ use cw_utils::PaymentError::{MultipleDenoms, NoFunds};
 use skip::{
     entry_point::{Action, Affiliate, ExecuteMsg},
     error::SkipError::{
-        SwapOperationsCoinInDenomMismatch, SwapOperationsCoinOutDenomMismatch, SwapOperationsEmpty,
+        SwapOperationsCoinInDenomMismatch, SwapOperationsCoinOutDenomMismatch, SwapOperationsEmpty, IbcFeesNotOneCoin
     },
     ibc::{IbcFee, IbcInfo},
     swap::{ExecuteMsg as SwapExecuteMsg, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
@@ -33,6 +33,8 @@ Expect Error
     - Fee Swap Last Swap Operation Denom Out Is Not The Same As IBC Fee Coin Denom
     - Fee Swap Without IBC Transfer
     - Fee Swap With IBC Trnasfer But Without IBC Fees
+    - Fee Swap With IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified
+    - Fee Swap With IBC Transfer With IBC Fees But No IBC Fee Coins Specified
 
     // User Swap
     - User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
@@ -731,6 +733,102 @@ struct Params {
         expected_error: Some(ContractError::FeeSwapWithoutIbcFees),
     };
     "Fee Swap With IBC Trnasfer But Without IBC Fees - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![
+            Coin::new(1_000_000, "osmo"),
+        ],
+        fee_swap: Some(
+            SwapExactCoinOut {
+                swap_venue_name: "swap_venue_name".to_string(), 
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "untrn".to_string(),
+                    }
+                ],
+                refund_address: None,
+            }
+        ),
+        user_swap: SwapExactCoinIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            operations: vec![
+                SwapOperation {
+                    pool: "pool_2".to_string(),
+                    denom_in: "osmo".to_string(),
+                    denom_out: "atom".to_string(),
+                }
+            ],
+        },
+        min_coin: Coin::new(100_000, "atom"),
+        timeout_timestamp: 101,
+        post_swap_action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: Some(IbcFee {
+                    recv_fee: vec![],
+                    ack_fee: vec![Coin::new(100_000, "uatom")],
+                    timeout_fee: vec![Coin::new(100_000, "untrn")],
+                }),
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+        },
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Skip(IbcFeesNotOneCoin)),
+    };
+    "Fee Swap With IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![
+            Coin::new(1_000_000, "osmo"),
+        ],
+        fee_swap: Some(
+            SwapExactCoinOut {
+                swap_venue_name: "swap_venue_name".to_string(), 
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "untrn".to_string(),
+                    }
+                ],
+                refund_address: None,
+            }
+        ),
+        user_swap: SwapExactCoinIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            operations: vec![
+                SwapOperation {
+                    pool: "pool_2".to_string(),
+                    denom_in: "osmo".to_string(),
+                    denom_out: "atom".to_string(),
+                }
+            ],
+        },
+        min_coin: Coin::new(100_000, "atom"),
+        timeout_timestamp: 101,
+        post_swap_action: Action::IbcTransfer {
+            ibc_info: IbcInfo {
+                source_channel: "channel-0".to_string(),
+                receiver: "receiver".to_string(),
+                memo: "".to_string(),
+                fee: Some(IbcFee {
+                    recv_fee: vec![],
+                    ack_fee: vec![],
+                    timeout_fee: vec![],
+                }),
+                recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
+                    .to_string(),
+            },
+        },
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Skip(IbcFeesNotOneCoin)),
+    };
+    "Fee Swap With IBC Transfer With IBC Fees But No IBC Fee Coins Specified - Expect Error")]
 #[test_case(
     Params {
         info_funds: vec![],

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -8,7 +8,8 @@ use cw_utils::PaymentError::{MultipleDenoms, NoFunds};
 use skip::{
     entry_point::{Action, Affiliate, ExecuteMsg},
     error::SkipError::{
-        SwapOperationsCoinInDenomMismatch, SwapOperationsCoinOutDenomMismatch, SwapOperationsEmpty, IbcFeesNotOneCoin
+        IbcFeesNotOneCoin, SwapOperationsCoinInDenomMismatch, SwapOperationsCoinOutDenomMismatch,
+        SwapOperationsEmpty,
     },
     ibc::{IbcFee, IbcInfo},
     swap::{ExecuteMsg as SwapExecuteMsg, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},

--- a/packages/skip/src/error.rs
+++ b/packages/skip/src/error.rs
@@ -19,4 +19,8 @@ pub enum SkipError {
 
     #[error("Last Swap Operations' Denom Out Differs From Swap Coin Out Denom")]
     SwapOperationsCoinOutDenomMismatch,
+
+    // IBC FEES
+    #[error("Ibc Fees Are Not A Single Coin, Either Multiple Denoms Or No Coin Specified")]
+    IbcFeesNotOneCoin,
 }

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -1,4 +1,4 @@
-use crate::proto_coin::ProtoCoin;
+use crate::{error::SkipError, proto_coin::ProtoCoin};
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::{Coin, Coins, StdError};
 use neutron_proto::neutron::feerefunder::Fee as NeutronFee;
@@ -98,6 +98,18 @@ impl TryFrom<IbcFee> for Coins {
             .try_for_each(|coin| ibc_fees.add(coin))?;
 
         Ok(ibc_fees)
+    }
+}
+
+impl IbcFee {
+    pub fn one_coin(&self) -> Result<Coin, SkipError> {
+        let ibc_fees_map: Coins = self.clone().try_into()?;
+
+        if ibc_fees_map.len() != 1 {
+            return Err(SkipError::IbcFeesNotOneCoin);
+        }
+
+        Ok(ibc_fees_map.to_vec().first().unwrap().clone())
     }
 }
 

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -158,7 +158,6 @@ where
 #[cw_serde]
 pub struct SwapExactCoinOut {
     pub swap_venue_name: String,
-    pub coin_out: Coin,
     pub operations: Vec<SwapOperation>,
     pub refund_address: Option<String>,
 }


### PR DESCRIPTION
## Background
- Previously, the contract accepted a `coin_out` param in `SwapExactCoinOut`, but the logic would essentially ensure this `coin_out` provided matched the actual fees given in `ibc_info.fee`.
- So, since we made this enforcement, a simplification and safer flow from a caller would be such that the fee swap `coin_out` is directly derived from the provided ibc fees itself, leaving no way for the caller to specify an incorrect `coin_out`.

## This PR
- Removes the `coin_out` field from `SwapExactCoinOut`
- Implements a `one_coin` method on IbcFee to ensure that if it provided it is exactly one coin (since the rest of the contract can't handle multiple ibc fee swaps anyways, and since it's an Option it should be set to None if no ibc fees are required)
- Changes the entry point contract to derive the fee swap coin out from the ibc fees
- Adds tests