### PR TITLE
✨ Change user_swap to a Swap enum

### DIFF
--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -12,7 +12,7 @@ use skip::{
         SwapOperationsEmpty,
     },
     ibc::{IbcFee, IbcInfo},
-    swap::{ExecuteMsg as SwapExecuteMsg, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
+    swap::{ExecuteMsg as SwapExecuteMsg, Swap, SwapExactCoinIn, SwapExactCoinOut, SwapOperation},
 };
 use skip_swap_entry_point::{error::ContractError, state::SWAP_VENUE_MAP};
 use test_case::test_case;
@@ -60,7 +60,7 @@ Expect Error
 struct Params {
     info_funds: Vec<Coin>,
     fee_swap: Option<SwapExactCoinOut>,
-    user_swap: SwapExactCoinIn,
+    user_swap: Swap,
     min_coin: Coin,
     timeout_timestamp: u64,
     post_swap_action: Action,
@@ -75,16 +75,18 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            }
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -138,16 +140,18 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(800_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -223,16 +227,18 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -312,16 +318,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -428,16 +436,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -480,16 +490,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -528,16 +540,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -576,16 +590,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -612,16 +628,18 @@ struct Params {
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -637,16 +655,18 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(800_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -673,16 +693,18 @@ struct Params {
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -710,16 +732,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "atom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "atom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -747,16 +771,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "atom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "atom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -791,16 +817,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "atom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "atom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -839,16 +867,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "atom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "atom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "atom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -873,16 +903,18 @@ struct Params {
     Params {
         info_funds: vec![],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -899,16 +931,18 @@ struct Params {
             Coin::new(1_000_000, "osmo"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool".to_string(),
-                    denom_in: "untrn".to_string(),
-                    denom_out: "osmo".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -924,10 +958,12 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 101,
         post_swap_action: Action::BankSend {
@@ -949,16 +985,18 @@ struct Params {
                 refund_address: None,
             }
         ),
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![
-                SwapOperation {
-                    pool: "pool_2".to_string(),
-                    denom_in: "osmo".to_string(),
-                    denom_out: "uatom".to_string(),
-                }
-            ],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+            },
+        ),
         min_coin: Coin::new(100_000, "uatom"),
         timeout_timestamp: 101,
         post_swap_action: Action::IbcTransfer {
@@ -985,10 +1023,12 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
         ],
         fee_swap: None,
-        user_swap: SwapExactCoinIn {
-            swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![],
-        },
+        user_swap: Swap::SwapExactCoinIn (
+            SwapExactCoinIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![],
+            },
+        ),
         min_coin: Coin::new(1_000_000, "osmo"),
         timeout_timestamp: 99,
         post_swap_action: Action::BankSend {

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -3,7 +3,7 @@ use cosmwasm_std::{Binary, Coin, Uint128};
 
 use crate::{
     ibc::IbcInfo,
-    swap::{SwapExactCoinIn, SwapExactCoinOut, SwapVenue},
+    swap::{Swap, SwapExactCoinOut, SwapVenue},
 };
 
 ///////////////////
@@ -25,7 +25,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     SwapAndAction {
         fee_swap: Option<SwapExactCoinOut>,
-        user_swap: SwapExactCoinIn,
+        user_swap: Swap,
         min_coin: Coin,
         timeout_timestamp: u64,
         post_swap_action: Action,

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -170,6 +170,12 @@ pub struct SwapExactCoinIn {
     pub operations: Vec<SwapOperation>,
 }
 
+#[cw_serde]
+pub enum Swap {
+    SwapExactCoinIn(SwapExactCoinIn),
+    SwapExactCoinOut(SwapExactCoinOut),
+}
+
 ////////////////////////
 /// COMMON FUNCTIONS ///
 ////////////////////////


### PR DESCRIPTION
This PR:
1. Creates a `Swap` enum that has two variants `SwapExactCoinIn` and `SwapExactCoinOut`
2. Changes `user_swap` from type `SwapExactCoinIn` to `Swap` enum while only supporting the `SwapExactCoinIn` variant
3. Updates test

A future PR will implement the actual `SwapExactCoinOut` logic