### PR TITLE
✨ Implement Swap Exact Coin Out Logic For User Swap

### DIFF
--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -50,7 +50,7 @@ pub enum ContractError {
     /////////////////
     /// USER SWAP ///
     /////////////////
-    
+
     #[error("User Swap Coin In Denom Differs From Coin Sent To Contract")]
     UserSwapCoinInDenomMismatch,
 

--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -47,6 +47,16 @@ pub enum ContractError {
     #[error("Fee Swap Coin In Denom Differs From Coin Sent To Contract")]
     FeeSwapCoinInDenomMismatch,
 
+    /////////////////
+    /// USER SWAP ///
+    /////////////////
+    
+    #[error("User Swap Coin In Denom Differs From Coin Sent To Contract")]
+    UserSwapCoinInDenomMismatch,
+
+    #[error("No Refund Address Provided For Swap Exact Coin Out User Swap")]
+    NoRefundAddress,
+
     ////////////////////////
     /// POST SWAP ACTION ///
     ////////////////////////

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -211,7 +211,7 @@ pub fn execute_user_swap(
                 amount: min_coin.amount.checked_add(total_affiliate_fee_amount)?,
             };
 
-            // Query the swap adapter to get the coin in needed for the user swap plus affiliates
+            // Query the swap adapter to get the coin in needed to obtain the min coin plus affiliates
             let user_swap_coin_in = query_swap_coin_in(
                 &deps,
                 &user_swap_adapter_contract_address,
@@ -229,8 +229,7 @@ pub fn execute_user_swap(
                 .amount
                 .checked_sub(user_swap_coin_in.amount)?;
 
-            // If the refund amount is greater than zero, then create the refund message
-            // and add it to the response
+            // If refund amount gt zero, then create the refund message and add it to the response
             if refund_amount > Uint128::zero() {
                 // Get the refund address from the swap
                 let to_address = swap
@@ -243,7 +242,7 @@ pub fn execute_user_swap(
 
                 // Create the refund message
                 let refund_msg = BankMsg::Send {
-                    to_address,
+                    to_address: to_address.clone(),
                     amount: vec![Coin {
                         denom: remaining_coin.denom,
                         amount: refund_amount,
@@ -254,7 +253,7 @@ pub fn execute_user_swap(
                 response = response
                     .add_message(refund_msg)
                     .add_attribute("action", "dispatch_refund")
-                    .add_attribute("address", &info.sender)
+                    .add_attribute("address", &to_address)
                     .add_attribute("amount", refund_amount);
             }
 

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -238,7 +238,7 @@ pub fn execute_user_swap(
                         .clone()
                         .ok_or(ContractError::NoRefundAddress)?,
                     amount: vec![Coin {
-                        denom: remaining_coin.denom.clone(),
+                        denom: remaining_coin.denom,
                         amount: refund_amount,
                     }],
                 };

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -123,6 +123,7 @@ pub fn execute_swap_and_action(
         .add_attribute("action", "dispatch_post_swap_action"))
 }
 
+// Dispatches the user swap and refund/affiliate fee bank sends if needed
 pub fn execute_user_swap(
     deps: DepsMut,
     env: Env,

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -29,7 +29,7 @@ Expect Response
 Expect Error
     // Fee Swap
     - Fee Swap Coin In Amount More Than Remaining Coin Received Amount
-    - Fee Swap Coin In Denom In Not The Same As Remaining Coin Received Denom
+    - Fee Swap Coin In Denom Is Not The Same As Remaining Coin Received Denom
     - Fee Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
     - Fee Swap Last Swap Operation Denom Out Is Not The Same As IBC Fee Coin Denom
     - Fee Swap Without IBC Transfer

--- a/contracts/entry-point/tests/test_user_swap.rs
+++ b/contracts/entry-point/tests/test_user_swap.rs
@@ -18,9 +18,9 @@ use test_case::test_case;
 Test Cases:
 
 Expect Response
-    - User Swap With No Affiliates
-    - User Swap With Single Affiliate
-    - User Swap With Multiple Affiliates
+    - User Swap Exact Coin In With No Affiliates
+    - User Swap Exact Coin In With Single Affiliate
+    - User Swap Exact Coin In With Multiple Affiliates
 
 Expect Error
     - User Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
@@ -83,7 +83,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "User Swap With No Affiliates")]
+    "User Swap Exact Coin In With No Affiliates")]
 #[test_case(
     Params {
         caller: "entry_point".to_string(),
@@ -138,7 +138,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "User Swap With Single Affiliate")]
+    "User Swap Exact Coin In With Single Affiliate")]
 #[test_case(
     Params {
         caller: "entry_point".to_string(),
@@ -209,7 +209,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "User Swap With Multiple Affiliates")]
+    "User Swap Exact Coin In With Multiple Affiliates")]
 #[test_case(
     Params {
         caller: "entry_point".to_string(),

--- a/contracts/entry-point/tests/test_user_swap.rs
+++ b/contracts/entry-point/tests/test_user_swap.rs
@@ -37,6 +37,9 @@ Expect Error
     - User Swap Exact Coin In Empty Swap Operations
 
     // Swap Exact Coin Out
+    - User Swap Exact Coin Out First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
+    - User Swap Exact Coin Out Last Swap Operation Denom Out Is Not The Same As Min Coin Out Denom
+    - User Swap Exact Coin Out Empty Swap Operations
     - User Swap Exact Coin Out With No Refund Address
     - User Swap Exact Coin Out Where Coin In Denom Is Not The Same As Remaining Coin Received Denom
     - User Swap Exact Coin Out Where Coin In Amount More Than Remaining Coin Received Amount
@@ -532,6 +535,69 @@ struct Params {
         expected_error: Some(ContractError::Skip(SwapOperationsEmpty)),
     };
     "User Swap Exact Coin In Empty Swap Operations - Expect Error")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        user_swap: Swap::SwapExactCoinOut (
+            SwapExactCoinOut{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "uatom".to_string(),
+                    }
+                ],
+                refund_address: Some("refund_address".to_string()),
+            },
+        ),
+        remaining_coin: Coin::new(1_000_000, "uosmo"),
+        min_coin: Coin::new(100_000, "uatom"),
+        affiliates: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Skip(SwapOperationsCoinInDenomMismatch)),
+    };
+    "User Swap Exact Coin Out First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom - Expect Error")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        user_swap: Swap::SwapExactCoinOut (
+            SwapExactCoinOut{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "osmo".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+                refund_address: Some("refund_address".to_string()),
+            },
+        ),
+        remaining_coin: Coin::new(1_000_000, "osmo"),
+        min_coin: Coin::new(100_000, "uatom"),
+        affiliates: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Skip(SwapOperationsCoinOutDenomMismatch)),
+    };
+    "User Swap Exact Coin Out Last Swap Operation Denom Out Is Not The Same As Min Coin Out Denom - Expect Error")]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        user_swap: Swap::SwapExactCoinOut (
+            SwapExactCoinOut{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![],
+                refund_address: Some("refund_address".to_string()),
+            },
+        ),
+        remaining_coin: Coin::new(1_000_000, "untrn"),
+        min_coin: Coin::new(1_000_000, "osmo"),
+        affiliates: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Skip(SwapOperationsEmpty)),
+    };
+    "User Swap Exact Coin Out Empty Swap Operations - Expect Error")]
 #[test_case(
     Params {
         caller: "entry_point".to_string(),


### PR DESCRIPTION
This PR:
- Implements the logic for when a `user_swap`'s `swap` enum is of the variant `SwapExactCoinOut`. 
    - When this happens, the entry point logic queries the swap adapter to get the `coin_in` required to obtain the specified `coin_out` (which is the `min_coin` specified by the user plus the amounts required for the affiliate fees). 
    - Then it creates a refund bank send to send back to the `refund_address` provided if the refund amount > 0. 
    - Then it dispatches the user swap
    - Then it dispatches any affiliate fee bank sends (after the user swap so that the contract has enough balance)
- Adds tests for both success and error cases

Future PR:
- A future PR will aim to reduce copied code across fee swap and user swap logic, this PR implements the core logic in a flat manner without abstracting. 