### PR TITLE
⬆️ Upgrade Rustc, Workspace, and Optimizer Version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "skip"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astroport",
  "cosmos-sdk-proto 0.19.0",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "skip-swap-entry-point"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
@@ -1036,7 +1036,7 @@ dependencies = [
 
 [[package]]
 name = "skip-swap-neutron-astroport-swap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "astroport",
  "cosmwasm-schema",
@@ -1050,7 +1050,7 @@ dependencies = [
 
 [[package]]
 name = "skip-swap-neutron-ibc-transfer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmos-sdk-proto 0.19.0",
  "cosmwasm-std",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "skip-swap-osmosis-ibc-transfer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-std",
  "cw-storage-plus 1.1.0",
@@ -1080,7 +1080,7 @@ dependencies = [
 
 [[package]]
 name = "skip-swap-osmosis-poolmanager-swap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,10 @@ members  = [
 ]
 
 [workspace.package]
-version       = "0.1.0"
+version       = "0.2.0"
 authors       = ["Skip"]
 edition       = "2021"
-rust-version  = "1.68.0"
+rust-version  = "1.71.0"
 license       = "TBD"
 homepage      = "https://skip.money/"
 repository    = "https://github.com/skip-mev/swap-contracts"

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@ optimize:
 		--mount type=volume,source="$(notdir $(CURDIR))_cache",target=/code/target \
 		--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
 		--platform linux/arm64 \
-		cosmwasm/workspace-optimizer-arm64:0.13.0; else \
+		cosmwasm/workspace-optimizer-arm64:0.14.0; else \
 	docker run --rm -v "$(CURDIR)":/code \
 		--mount type=volume,source="$(notdir $(CURDIR))_cache",target=/code/target \
 		--mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
 		--platform linux/amd64 \
-		cosmwasm/workspace-optimizer:0.13.0; fi
+		cosmwasm/workspace-optimizer:0.14.0; fi


### PR DESCRIPTION
This PR upgrades:
- rustc to 1.71.0
- workspace to 0.2.0
- cosmwasm optimizer to 0.14.0