### PR TITLE
🐛 Enforce Coin Sent is Exact In Post Swap Actions if User Swap Is Swap Exact Out

### DIFF
--- a/contracts/entry-point/src/contract.rs
+++ b/contracts/entry-point/src/contract.rs
@@ -113,6 +113,7 @@ pub fn execute(
             min_coin,
             timeout_timestamp,
             post_swap_action,
+            exact_out,
         } => execute_post_swap_action(
             deps,
             env,
@@ -120,6 +121,7 @@ pub fn execute(
             min_coin,
             timeout_timestamp,
             post_swap_action,
+            exact_out,
         ),
     }
 }

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -21,10 +21,11 @@ use test_case::test_case;
 Test Cases:
 
 Expect Response
-    - User Swap With Bank Send
-    - User Swap With IBC Transfer With IBC Fees
-    - User Swap With IBC Transfer Without IBC Fees
-    - Fee Swap And User Swap With IBC Fees
+    - User Swap Exact Coin In With Bank Send
+    - User Swap Exact Coin Out With Bank Send
+    - User Swap Exact Coin In With IBC Transfer With IBC Fees
+    - User Swap Exact Coin In With IBC Transfer Without IBC Fees
+    - Fee Swap And User Swap Exact Coin In With IBC Fees
 
 Expect Error
     // Fee Swap
@@ -129,6 +130,7 @@ struct Params {
                         post_swap_action: Action::BankSend {
                             to_address: "to_address".to_string(),
                         },
+                        exact_out: false,
                     }).unwrap(),
                     funds: vec![],
                 }
@@ -139,7 +141,83 @@ struct Params {
         ],
         expected_error: None,
     };
-    "User Swap With Bank Send")]
+    "User Swap Exact Coin In With Bank Send")]
+#[test_case(
+    Params {
+        info_funds: vec![
+            Coin::new(1_000_000, "untrn"),
+        ],
+        fee_swap: None,
+        user_swap: Swap::SwapExactCoinOut (
+            SwapExactCoinOut{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+                refund_address: Some("refund_address".to_string()),
+            }
+        ),
+        min_coin: Coin::new(1_000_000, "osmo"),
+        timeout_timestamp: 101,
+        post_swap_action: Action::BankSend {
+            to_address: "to_address".to_string(),
+        },
+        affiliates: vec![],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "entry_point".to_string(), 
+                    msg: to_binary(&ExecuteMsg::UserSwap {
+                        swap: Swap::SwapExactCoinOut (
+                            SwapExactCoinOut{
+                                swap_venue_name: "swap_venue_name".to_string(),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "untrn".to_string(),
+                                        denom_out: "osmo".to_string(),
+                                    }
+                                ],
+                                refund_address: Some("refund_address".to_string()),
+                            }
+                        ),
+                        remaining_coin: Coin::new(1_000_000, "untrn"),
+                        min_coin: Coin::new(1_000_000, "osmo"),
+                        affiliates: vec![],
+                    }).unwrap(),
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "entry_point".to_string(), 
+                    msg: to_binary(&ExecuteMsg::PostSwapAction {
+                        min_coin: Coin::new(1_000_000, "osmo"),
+                        timeout_timestamp: 101,
+                        post_swap_action: Action::BankSend {
+                            to_address: "to_address".to_string(),
+                        },
+                        exact_out: true,
+                    }).unwrap(),
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "User Swap Exact Coin Out With Bank Send")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -224,6 +302,7 @@ struct Params {
                                     .to_string(),
                             },
                         },
+                        exact_out: false,
                     }).unwrap(),
                     funds: vec![],
                 }
@@ -234,7 +313,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "User Swap With IBC Transfer With IBC Fees")]
+    "User Swap Exact Coin In With IBC Transfer With IBC Fees")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -311,6 +390,7 @@ struct Params {
                                     .to_string(),
                             },
                         },
+                        exact_out: false,
                     }).unwrap(),
                     funds: vec![],
                 }
@@ -321,7 +401,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "User Swap With IBC Transfer Without IBC Fees")]
+    "User Swap Exact Coin In With IBC Transfer Without IBC Fees")]
 #[test_case(
     Params {
         info_funds: vec![
@@ -437,6 +517,7 @@ struct Params {
                                     .to_string(),
                             },
                         },
+                        exact_out: false,
                     }).unwrap(),
                     funds: vec![],
                 }
@@ -447,7 +528,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "Fee Swap And User Swap With IBC Fees")]
+    "Fee Swap And User Swap Exact Coin In With IBC Fees")]
 #[test_case(
     Params {
         info_funds: vec![

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -41,6 +41,7 @@ pub enum ExecuteMsg {
         min_coin: Coin,
         timeout_timestamp: u64,
         post_swap_action: Action,
+        exact_out: bool,
     },
 }
 


### PR DESCRIPTION
## Background
- The post swap action logic relies on querying the contract balance and then doing things with it. Under circumstances where there is no dust on contract, the swap exact out logic worked as expected because the swap only obtains the exact correct amount which is then used.
- However, if there is any dust left on the entry point contract in the desired out denom, then the post swap action logic would also send those funds, making the actual transferred coin (whether it was a bank send, contract call, or ibc transfer) to be the min_coin + leftover dust.
- This is a bug

## This PR
- Passes an `exact_out` boolean to the `PostSwapAction` call based on what the user swap is.
- When the boolean is true, forces the min_coin to be the coin used in bank sends, contract calls, and ibc transfers
- Updates tests for this

## NOTE
- When the post swap action is an ibc transfer, the funds sent to the ibc transfer contract are still the entire funds , but the `coin` parameter is set to the `min_coin`. The `coin` param decides the `coin` sent via the ibc transfer itself. Sending the funds to the ibc transfer adapter contract will then refund the user's recovery address those funds during the packet response logic.