### PR TITLE
🔥 Consolidate Neutron and Osmosis Query enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Minor Improvements
 - [#52](https://github.com/skip-mev/skip-api-contracts/pull/52) Ensure Skip package types, methods, and functions are well documented.
+- [#53](https://github.com/skip-mev/skip-api-contracts/pull/53) Consolidate Neutron and Osmosis QueryMsg enum's into one enum.
 
 ## [v0.2.0](https://github.com/skip-mev/skip-api-contracts/releases/tag/v0.2.0) - 2023-08-03
 

--- a/contracts/networks/neutron/ibc-transfer/src/contract.rs
+++ b/contracts/networks/neutron/ibc-transfer/src/contract.rs
@@ -10,7 +10,7 @@ use neutron_proto::neutron::transfer::{MsgTransfer, MsgTransferResponse};
 use neutron_sdk::sudo::msg::{RequestPacket, TransferSudoMsg};
 use prost::Message;
 use skip::{
-    ibc::{AckID, ExecuteMsg, IbcInfo, InstantiateMsg, NeutronQueryMsg as QueryMsg},
+    ibc::{AckID, ExecuteMsg, IbcInfo, InstantiateMsg, QueryMsg},
     proto_coin::ProtoCoin,
     sudo::SudoType,
 };

--- a/contracts/networks/osmosis/ibc-transfer/src/contract.rs
+++ b/contracts/networks/osmosis/ibc-transfer/src/contract.rs
@@ -13,10 +13,7 @@ use ibc_proto::ibc::applications::transfer::v1::{MsgTransfer, MsgTransferRespons
 use prost::Message;
 use serde_cw_value::Value;
 use skip::{
-    ibc::{
-        AckID, ExecuteMsg, IbcInfo, IbcLifecycleComplete, InstantiateMsg,
-        OsmosisQueryMsg as QueryMsg,
-    },
+    ibc::{AckID, ExecuteMsg, IbcInfo, IbcLifecycleComplete, InstantiateMsg, QueryMsg},
     proto_coin::ProtoCoin,
     sudo::{OsmosisSudoMsg as SudoMsg, SudoType},
 };

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -34,23 +34,10 @@ pub enum ExecuteMsg {
 /// QUERY ///
 /////////////
 
-// TODO: Consolidate into one enum now that the return types are the same
-
-// The NeutronQueryMsg enum defines the queries the Neutron IBC Transfer Adapter Contract provides.
+// The QueryMsg enum defines the queries the IBC Transfer Adapter Contract provides.
 #[cw_serde]
 #[derive(QueryResponses)]
-pub enum NeutronQueryMsg {
-    #[returns(String)]
-    InProgressRecoverAddress {
-        channel_id: String,
-        sequence_id: u64,
-    },
-}
-
-// The OsmosisQueryMsg enum defines the queries the Osmosis IBC Transfer Adapter Contract provides.
-#[cw_serde]
-#[derive(QueryResponses)]
-pub enum OsmosisQueryMsg {
+pub enum QueryMsg {
     #[returns(String)]
     InProgressRecoverAddress {
         channel_id: String,


### PR DESCRIPTION
## Background
- Previously, IBC transfer adapter contracts stored a struct that was network-specific given an ack id. This was changed in #19 to instead just store an address as a String (verified as a a valid address in entry point) on both contracts.
- This allows us to then use the same query enum for both networks

## This PR
- Consolidates the multiple query enums into one.