### PR TITLE
♻️ Refactor Fee Swap Into Ibc Transfer Variant of Action Enum

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,6 +95,6 @@ jobs:
         run: |
           cargo +nightly run --package skip-api-entry-point --bin schema     
           if [[ `git status --porcelain` ]]; then
-            echo "Schema is different, please run make entry-point schema"
+            echo "Schema is different, please run make schema"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Minor Code Improvements
 - [#53](https://github.com/skip-mev/skip-api-contracts/pull/53) Consolidate Neutron and Osmosis QueryMsg enum's into one enum.
+- [#63](https://github.com/skip-mev/skip-api-contracts/pull/63) Refactor Fee Swap Into Ibc Transfer Variant of Action Enum
 
 ### Minor Testing Improvements
 - [#55](https://github.com/skip-mev/skip-api-contracts/pull/55) Add unit tests to methods and functions in Skip packages folder.
@@ -51,7 +52,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - [#59](https://github.com/skip-mev/skip-api-contracts/pull/59) Add cargo fmt check in github workflow
 - [#60](https://github.com/skip-mev/skip-api-contracts/pull/60) Update github workflow to also run on push to main
 - [#61](https://github.com/skip-mev/skip-api-contracts/pull/61) Add Skip package path to workspace cargo.toml
-- [#64](https://github.com/skip-mev/skip-api-contracts/pull/61) Add Json Schema Generation
+- [#64](https://github.com/skip-mev/skip-api-contracts/pull/64) Add Json Schema Generation
+- [#65](https://github.com/skip-mev/skip-api-contracts/pull/65) Restructure Contracts Folder From networks/ to adapters/
 
 ## [v0.2.0](https://github.com/skip-mev/skip-api-contracts/releases/tag/v0.2.0) - 2023-08-03
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ fmt:
 
 # Only generates the entry point schema since that is the only
 # contract that can be called externally.
-entry-point schema:
+schema:
 	cargo run --package skip-api-entry-point --bin schema         
 
 test:

--- a/contracts/entry-point/README.md
+++ b/contracts/entry-point/README.md
@@ -57,16 +57,6 @@ SwapExactCoinIn:
 ``` json
 {
     "swap_and_action": {
-        "fee_swap": {
-            "swap_venue_name": "neutron-astroport",
-            "operations": [
-                {
-                    "pool": "neutron...",
-                    "denom_in": "uatom",
-                    "denom_out": "untrn"
-                }
-            ]
-        },
         "user_swap": {
             "swap_exact_coin_in": {
                 "swap_venue_name": "neutron-astroport",
@@ -90,8 +80,38 @@ SwapExactCoinIn:
         },
         "timeout_timestamp": 1000000000000,
         "post_swap_action": {
-            "bank_send": {
-                "to_address": "neutron..."
+            "ibc_transfer": {
+                "ibc_info": {
+                    "source_channel": "channel-1",
+                    "receiver": "cosmos...",
+                    "fee": {
+                        "recv_fee": [],
+                        "ack_fee": [
+                            {
+                                "denom": "untrn",
+                                "amount": "100"
+                            }
+                        ],
+                        "timeout_fee": [
+                            {
+                                "denom": "untrn",
+                                "amount": "100"
+                            }
+                        ]
+                    },
+                    "memo": "",
+                    "recover_address": "neutron..."
+                }
+                "fee_swap": {
+                    "swap_venue_name": "neutron-astroport",
+                    "operations": [
+                        {
+                            "pool": "neutron...",
+                            "denom_in": "uatom",
+                            "denom_out": "untrn"
+                        }
+                    ]
+                },
             }
         },
         "affiliates": [
@@ -109,16 +129,6 @@ SwapExactCoinOut:
 ``` json
 {
     "swap_and_action": {
-        "fee_swap": {
-            "swap_venue_name": "neutron-astroport",
-            "operations": [
-                {
-                    "pool": "neutron...",
-                    "denom_in": "uatom",
-                    "denom_out": "untrn"
-                }
-            ]
-        },
         "user_swap": {
             "swap_exact_coin_out": {
                 "swap_venue_name": "neutron-astroport",

--- a/contracts/entry-point/src/contract.rs
+++ b/contracts/entry-point/src/contract.rs
@@ -86,7 +86,6 @@ pub fn execute(
 ) -> ContractResult<Response> {
     match msg {
         ExecuteMsg::SwapAndAction {
-            fee_swap,
             user_swap,
             min_coin,
             timeout_timestamp,
@@ -96,7 +95,6 @@ pub fn execute(
             deps,
             env,
             info,
-            fee_swap,
             user_swap,
             min_coin,
             timeout_timestamp,

--- a/contracts/entry-point/src/error.rs
+++ b/contracts/entry-point/src/error.rs
@@ -41,9 +41,6 @@ pub enum ContractError {
     #[error("Fee Swap Not Allowed: No IBC Fees Provided")]
     FeeSwapWithoutIbcFees,
 
-    #[error("Fee Swap Not Allowed: No Post Swap Action IBC Transfer")]
-    FeeSwapWithoutIbcTransfer,
-
     #[error("Fee Swap Coin In Denom Differs From Coin Sent To Contract")]
     FeeSwapCoinInDenomMismatch,
 

--- a/contracts/entry-point/tests/test_execute_post_swap_action.rs
+++ b/contracts/entry-point/tests/test_execute_post_swap_action.rs
@@ -107,6 +107,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         exact_out: false,
         expected_messages: vec![SubMsg {
@@ -148,6 +149,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         exact_out: true,
         expected_messages: vec![SubMsg {
@@ -193,6 +195,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         exact_out: true,
         expected_messages: vec![SubMsg {
@@ -244,6 +247,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         exact_out: true,
         expected_messages: vec![SubMsg {
@@ -340,6 +344,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         exact_out: false,
         expected_messages: vec![SubMsg {
@@ -391,6 +396,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         exact_out: false,
         expected_messages: vec![SubMsg {

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -37,7 +37,6 @@ Expect Error
     - Fee Swap Coin In Denom Is Not The Same As Remaining Coin Received Denom
     - Fee Swap First Swap Operation Denom In Is Not The Same As Remaining Coin Received Denom
     - Fee Swap Last Swap Operation Denom Out Is Not The Same As IBC Fee Coin Denom
-    - Fee Swap Without IBC Transfer
     - Fee Swap With IBC Transfer But Without IBC Fees
 
     // User Swap
@@ -62,7 +61,6 @@ Expect Error
 // Define test parameters
 struct Params {
     info_funds: Vec<Coin>,
-    fee_swap: Option<SwapExactCoinOut>,
     user_swap: Swap,
     min_coin: Coin,
     timeout_timestamp: u64,
@@ -78,7 +76,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -152,7 +149,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinOut (
             SwapExactCoinOut{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -228,7 +224,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -256,6 +251,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         affiliates: vec![],
         expected_messages: vec![
@@ -316,6 +312,7 @@ struct Params {
                                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                                     .to_string(),
                             },
+                            fee_swap: None,
                         },
                         exact_out: false,
                     }).unwrap(),
@@ -334,7 +331,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -358,6 +354,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         affiliates: vec![],
         expected_messages: vec![
@@ -404,6 +401,7 @@ struct Params {
                                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                                     .to_string(),
                             },
+                            fee_swap: None,
                         },
                         exact_out: false,
                     }).unwrap(),
@@ -422,19 +420,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -462,6 +447,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![
@@ -541,6 +539,19 @@ struct Params {
                                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                                     .to_string(),
                             },
+                            fee_swap: Some(
+                                SwapExactCoinOut {
+                                    swap_venue_name: "swap_venue_name".to_string(), 
+                                    operations: vec![
+                                        SwapOperation {
+                                            pool: "pool".to_string(),
+                                            denom_in: "osmo".to_string(),
+                                            denom_out: "untrn".to_string(),
+                                        }
+                                    ],
+                                    refund_address: None,
+                                }
+                            ),
                         },
                         exact_out: false,
                     }).unwrap(),
@@ -559,19 +570,6 @@ struct Params {
         info_funds: vec![
             Coin::new(100_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -599,6 +597,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -614,19 +625,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "uatom"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "uatom".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -654,6 +652,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "uatom".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -665,19 +676,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "uatom".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -705,6 +703,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "uatom".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -716,19 +727,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "osmo".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -756,6 +754,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "osmo".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -767,7 +778,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -795,6 +805,7 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: None,
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -806,59 +817,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
-        user_swap: Swap::SwapExactCoinIn (
-            SwapExactCoinIn{
-                swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "atom".to_string(),
-                    }
-                ],
-            },
-        ),
-        min_coin: Coin::new(100_000, "atom"),
-        timeout_timestamp: 101,
-        post_swap_action: Action::BankSend {
-            to_address: "to_address".to_string(),
-        },
-        affiliates: vec![],
-        expected_messages: vec![],
-        expected_error: Some(ContractError::FeeSwapWithoutIbcTransfer),
-    };
-    "Fee Swap Without IBC Transfer - Expect Error")]
-#[test_case(
-    Params {
-        info_funds: vec![
-            Coin::new(1_000_000, "osmo"),
-        ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -882,6 +840,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -893,19 +864,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -933,6 +891,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -944,19 +915,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -984,6 +942,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -995,19 +966,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "untrn".to_string(),
-                    }
-                ],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1035,6 +993,19 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "osmo".to_string(),
+                            denom_out: "untrn".to_string(),
+                        }
+                    ],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -1044,7 +1015,6 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1073,7 +1043,6 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1101,13 +1070,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        fee_swap: Some(
-            SwapExactCoinOut {
-                swap_venue_name: "swap_venue_name".to_string(), 
-                operations: vec![],
-                refund_address: None,
-            }
-        ),
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1135,6 +1097,13 @@ struct Params {
                 recover_address: "cosmos1xv9tklw7d82sezh9haa573wufgy59vmwe6xxe5"
                     .to_string(),
             },
+            fee_swap: Some(
+                SwapExactCoinOut {
+                    swap_venue_name: "swap_venue_name".to_string(), 
+                    operations: vec![],
+                    refund_address: None,
+                }
+            ),
         },
         affiliates: vec![],
         expected_messages: vec![],
@@ -1146,7 +1115,6 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        fee_swap: None,
         user_swap: Swap::SwapExactCoinIn (
             SwapExactCoinIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1217,7 +1185,6 @@ fn test_execute_swap_and_action(params: Params) {
         env,
         info,
         ExecuteMsg::SwapAndAction {
-            fee_swap: params.fee_swap,
             user_swap: params.user_swap,
             min_coin: params.min_coin,
             timeout_timestamp: params.timeout_timestamp,

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -27,7 +27,6 @@ pub struct InstantiateMsg {
 #[allow(clippy::large_enum_variant)]
 pub enum ExecuteMsg {
     SwapAndAction {
-        fee_swap: Option<SwapExactCoinOut>,
         user_swap: Swap,
         min_coin: Coin,
         timeout_timestamp: u64,
@@ -79,6 +78,7 @@ pub enum Action {
     },
     IbcTransfer {
         ibc_info: IbcInfo,
+        fee_swap: Option<SwapExactCoinOut>,
     },
     ContractCall {
         contract_address: String,

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -25,16 +25,6 @@
                 "$ref": "#/definitions/Affiliate"
               }
             },
-            "fee_swap": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SwapExactCoinOut"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
             "min_coin": {
               "$ref": "#/definitions/Coin"
             },
@@ -164,6 +154,16 @@
                 "ibc_info"
               ],
               "properties": {
+                "fee_swap": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SwapExactCoinOut"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
                 "ibc_info": {
                   "$ref": "#/definitions/IbcInfo"
                 }

--- a/schema/skip-api-entry-point.json
+++ b/schema/skip-api-entry-point.json
@@ -70,16 +70,6 @@
                   "$ref": "#/definitions/Affiliate"
                 }
               },
-              "fee_swap": {
-                "anyOf": [
-                  {
-                    "$ref": "#/definitions/SwapExactCoinOut"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
-              },
               "min_coin": {
                 "$ref": "#/definitions/Coin"
               },
@@ -209,6 +199,16 @@
                   "ibc_info"
                 ],
                 "properties": {
+                  "fee_swap": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/SwapExactCoinOut"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
                   "ibc_info": {
                     "$ref": "#/definitions/IbcInfo"
                   }


### PR DESCRIPTION
## Background
- Previously, the contract would throw an error if a fee_swap was provided but the post swap action was not an ibc transfer/
- This is unnecessary as the fee_swap option could instead be placed into the ibc transfer variant of the post swap action enum, enforcing this requirement via the types themselves.

## This PR
- Refactors fee_swap by moving it into the Action enum's IbcTransfer variant
- Updates tests accordingly
- Changes entry point logic slightly to use an if let pattern instead of matching on the post swap action enum (since we only match on 1 variant now)