### PR TITLE
🐛 Astroport Slippage Fix

### DIFF
--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -4,10 +4,11 @@ use crate::{
 };
 use astroport::{
     asset::{Asset, AssetInfo},
-    pair::{QueryMsg as PairQueryMsg, ReverseSimulationResponse, MAX_ALLOWED_SLIPPAGE},
-    router::{
-        ExecuteMsg as RouterExecuteMsg, QueryMsg as RouterQueryMsg, SimulateSwapOperationsResponse,
+    pair::{
+        QueryMsg as PairQueryMsg, ReverseSimulationResponse, SimulationResponse,
+        MAX_ALLOWED_SLIPPAGE,
     },
+    router::ExecuteMsg as RouterExecuteMsg,
 };
 use cosmwasm_std::{
     entry_point, to_binary, Addr, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
@@ -181,7 +182,7 @@ fn query_simulate_swap_exact_coin_in(
     swap_operations: Vec<SwapOperation>,
 ) -> ContractResult<Coin> {
     // Error if swap operations is empty
-    let (Some(first_op), Some(last_op)) = (swap_operations.first(), swap_operations.last()) else {
+    let Some(first_op) = swap_operations.first() else {
         return Err(ContractError::SwapOperationsEmpty);
     };
 
@@ -190,29 +191,37 @@ fn query_simulate_swap_exact_coin_in(
         return Err(ContractError::CoinInDenomMismatch);
     }
 
-    // Get the router contract address
-    let router_contract_address = ROUTER_CONTRACT_ADDRESS.load(deps.storage)?;
+    // Iterate through the swap operations, querying the astroport pool contracts to get the coin out
+    // for each swap operation, and then updating the coin out for the next swap operation until the
+    // coin out for the last swap operation is found.
+    let coin_out = swap_operations.iter().try_fold(
+        coin_in,
+        |coin_out, operation| -> Result<_, ContractError> {
+            let res: SimulationResponse = deps.querier.query_wasm_smart(
+                &operation.pool,
+                &PairQueryMsg::Simulation {
+                    offer_asset: Asset {
+                        info: AssetInfo::NativeToken {
+                            denom: coin_out.denom,
+                        },
+                        amount: coin_out.amount,
+                    },
+                    ask_asset_info: None,
+                },
+            )?;
 
-    // Get denom out from last swap operation
-    let denom_out = last_op.denom_out.clone();
+            // Assert the operation does not exceed the max spread limit
+            assert_max_spread(res.return_amount, res.spread_amount)?;
 
-    // Convert the swap operations to astroport swap operations
-    let astroport_swap_operations = swap_operations.into_iter().map(From::from).collect();
-
-    // Query the astroport router contract to simulate the swap operations
-    let res: SimulateSwapOperationsResponse = deps.querier.query_wasm_smart(
-        router_contract_address,
-        &RouterQueryMsg::SimulateSwapOperations {
-            offer_amount: coin_in.amount,
-            operations: astroport_swap_operations,
+            Ok(Coin {
+                denom: operation.denom_out.clone(),
+                amount: res.return_amount,
+            })
         },
     )?;
 
     // Return the coin out
-    Ok(Coin {
-        denom: denom_out,
-        amount: res.amount,
-    })
+    Ok(coin_out)
 }
 
 // Queries the astroport pool contracts to simulate a multi-hop swap exact amount out

--- a/contracts/adapters/swap/astroport/src/error.rs
+++ b/contracts/adapters/swap/astroport/src/error.rs
@@ -29,4 +29,7 @@ pub enum ContractError {
 
     #[error("coin_out denom must match the last swap operation's denom out")]
     CoinOutDenomMismatch,
+
+    #[error("Operation exceeds max spread limit")]
+    MaxSpreadAssertion,
 }

--- a/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
@@ -4,7 +4,7 @@ use astroport::{
 };
 use cosmwasm_std::{
     testing::{mock_dependencies, mock_env, mock_info},
-    to_binary, Addr, Coin,
+    to_binary, Addr, Coin, Decimal,
     ReplyOn::Never,
     SubMsg, WasmMsg,
 };
@@ -69,7 +69,7 @@ struct Params {
                         ],
                         minimum_receive: None,
                         to: None,
-                        max_spread: None,
+                        max_spread: Some(Decimal::percent(50)),
                     })?,
                     funds: vec![Coin::new(100, "uosmo")],
                 }
@@ -136,7 +136,7 @@ struct Params {
                         ],
                         minimum_receive: None,
                         to: None,
-                        max_spread: None,
+                        max_spread: Some(Decimal::percent(50)),
                     })?,
                     funds: vec![Coin::new(100, "uosmo")],
                 }
@@ -175,7 +175,7 @@ struct Params {
                         operations: vec![],
                         minimum_receive: None,
                         to: None,
-                        max_spread: None,
+                        max_spread: Some(Decimal::percent(50)),
                     })?,
                     funds: vec![Coin::new(100, "uosmo")],
                 }

--- a/deployed-contracts/terra/mainnet.toml
+++ b/deployed-contracts/terra/mainnet.toml
@@ -1,30 +1,31 @@
 [info]
 chain_id = "phoenix-1"
 network = "mainnet"
-deploy_date = "01/11/2023 10:49:24"
-commit_hash = "e3ece7f86b707183d67521cda2587a20dc59c1e1"
+deploy_date = "10/11/2023 12:51:32"
+commit_hash = "755e391bdd308c2967184ad3b0440207f4583439"
 
 [checksums]
 "skip_api_entry_point-aarch64.wasm" = "2d4963276cf9504f4d1bcba0e52f9b8f4a774f0e5a84259fffc8db8b8db6fbe9"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "ae92e2dcd960e589e97dca8b111a8a90fe3cd79869b22a88a7ab6c9f10a75ad5"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "19951b963dc8fb77eeaca90557d75e918fc9f4096033ea81626b30bc7734c12e"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "cc552b9cba1f6e67601450687c735115799026ac0c786c9b3a5593b448fb2436"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "45b11c1b073b813702103c9c996e52810b997a77319e759422fcef58189a7351"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "fe2a2d2cac64f32a640278cd2d942090b88271f7ef134ce89f57e732253326d3"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "24ab8a5fb42b6c1bfe31833b951a6d287580876f7b5f225d196aa29b5f514cb6"
 
 [code-ids]
-swap_adapter_contract_code_id = 2017
-ibc_transfer_adapter_contract_code_id = 2018
-entry_point_contract_code_id = 2019
+swap_adapter_contract_code_id = "2077"
+ibc_transfer_adapter_contract_code_id = "2078"
+entry_point_contract_code_id = "2079"
 
 [contract-addresses]
-swap_adapter_contract_address = "terra1kmw2c99nnzmr7klt3c0z5ajtkml90gu4luczdmxzc3apkpqttdsql8tdxc"
-ibc_transfer_adapter_contract_address = "terra18n9c4auh3h5vwvpqxzy6d0sa4yalczss9fek67jkyshl4kd0t2xsfdcj45"
-entry_point_contract_address = "terra1k64frfgx3k5vxzkawm5lhtxfktm0s53lufnv2yk7tf3wj06557asraak09"
+swap_adapter_contract_address = "terra1t8nee3950224v8uwhavpfvlfatjfjdmlmav8smwheme3d76np2rsl0xenz"
+ibc_transfer_adapter_contract_address = "terra16jhtwk36um8kv7mcc0auc6tqknchhn83ym8ldzp2u6n32w5yuq6s693ncm"
+entry_point_contract_address = "terra1jzugwhg2fkuzcepmdfyydrhe0k7lzfhzrjgncm8e7430gkvat9hsyz07mw"
 
 [tx-hashes]
-store_swap_adapter_tx_hash = "37BFE33A5BB832EB0B37F781F85BC1349CDE60A0DD16FF782F1DBB0A0C9784FC"
-store_ibc_transfer_adapter_tx_hash = "53AE0FC525D60682F2D4B2A868F562D88A79D252795A9AE246867A747A1E50B6"
-store_entry_point_tx_hash = "7209903C1136BAF0C4FF13C9C8E466072488A0752F490029A426FB7D3DDCDE5C"
-instantiate_swap_adapter_tx_hash = "0BA1D4F596D96DFCC18583F8F3F0509837A09281F2C115C84B48C2F5127A1AB2"
-instantiate_ibc_transfer_adapter_tx_hash = "DA2A3A987114A0DB37841C42D21B2475C126D07AABCB001FA22DE2BCDABFEE7D"
-instantiate_entry_point_tx_hash = "21DE3E37DCE55B767CFC326EDED39B1E59C7A75D4819FBFEF8D3E4BFE2FDAB43"
+store_swap_adapter_tx_hash = "986b2285c5e426719c2c2934ebe43de1d2dd4c546c7aeb7092129eae9ca63344"
+store_ibc_transfer_adapter_tx_hash = "f6e061a3b640ac8c58906b7b85cc8aeeb5034120240daf9e75a2f0e91429188a"
+store_entry_point_tx_hash = "aa775f6445ea362fc8a18b7169efe68b6422af4b89075c39841d2004e7a4ffc1"
+instantiate_swap_adapter_tx_hash = "5c8f99df082d77be135fd4be92f026ba7d6b13e52567f05666ba840f7a92ba53"
+instantiate_ibc_transfer_adapter_tx_hash = "21f282a12a710da1d0213784a1bed94549bba30b924c52a662af92ba703206a3"
+instantiate_entry_point_tx_hash = "e660087cdee75e00f6ba50d4bf88cab1640f14a5c5631b32b7cffef3eb31874d"

--- a/deployed-contracts/terra/testnet.toml
+++ b/deployed-contracts/terra/testnet.toml
@@ -1,30 +1,31 @@
 [info]
 chain_id = "pisco-1"
 network = "testnet"
-deploy_date = "01/11/2023 19:23:18"
-commit_hash = "e3ece7f86b707183d67521cda2587a20dc59c1e1"
+deploy_date = "10/11/2023 14:19:56"
+commit_hash = "755e391bdd308c2967184ad3b0440207f4583439"
 
 [checksums]
 "skip_api_entry_point-aarch64.wasm" = "2d4963276cf9504f4d1bcba0e52f9b8f4a774f0e5a84259fffc8db8b8db6fbe9"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "ae92e2dcd960e589e97dca8b111a8a90fe3cd79869b22a88a7ab6c9f10a75ad5"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "19951b963dc8fb77eeaca90557d75e918fc9f4096033ea81626b30bc7734c12e"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "cc552b9cba1f6e67601450687c735115799026ac0c786c9b3a5593b448fb2436"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "45b11c1b073b813702103c9c996e52810b997a77319e759422fcef58189a7351"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "fe2a2d2cac64f32a640278cd2d942090b88271f7ef134ce89f57e732253326d3"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "24ab8a5fb42b6c1bfe31833b951a6d287580876f7b5f225d196aa29b5f514cb6"
 
 [code-ids]
-swap_adapter_contract_code_id = 11299
-ibc_transfer_adapter_contract_code_id = 11300
-entry_point_contract_code_id = 11301
+swap_adapter_contract_code_id = "11686"
+ibc_transfer_adapter_contract_code_id = "11688"
+entry_point_contract_code_id = "11690"
 
 [contract-addresses]
-swap_adapter_contract_address = "terra1gj6984mw5qshx43882pe53c7xxyd8n9236qgvr7rurqp7r568u6sfekrzq"
-ibc_transfer_adapter_contract_address = "terra1m4907dcrmygfhh24v75kfxukg4l9ke9584udhy2rd539nlppw7wq26lzcm"
-entry_point_contract_address = "terra1k64frfgx3k5vxzkawm5lhtxfktm0s53lufnv2yk7tf3wj06557asraak09"
+swap_adapter_contract_address = "terra16lh9s0wewq8ffq0v7fx89ds6xnzavr8krg920kh5udazc09lwwssafty4w"
+ibc_transfer_adapter_contract_address = "terra17qn3saulgyskcwcfc6x5te8m52lv505zef4xvz8pe0dkzdsl795qar9z5z"
+entry_point_contract_address = "terra1jzugwhg2fkuzcepmdfyydrhe0k7lzfhzrjgncm8e7430gkvat9hsyz07mw"
 
 [tx-hashes]
-store_swap_adapter_tx_hash = "7A8117ACC20FB453570FDED99B0A0DB22009E0C565A8363E937D648A64C6D717"
-store_ibc_transfer_adapter_tx_hash = "7890B2181CE200FBFEC3507CC75B6B23CFE889D3B59D36467B36027D7444E57F"
-store_entry_point_tx_hash = "D51715FEA312A4412C2AE0C2BF9B6182303D4956016E8DFE0F10DA91DBC83EB6"
-instantiate_swap_adapter_tx_hash = "CCF36D9D4650D1FEB28E97293AAAC5A8651694129F5C80AD1F300D47C88413B9"
-instantiate_ibc_transfer_adapter_tx_hash = "297BFC5A87B6DFF022BE3456303F89DCA38951FC68D6C11E2516C577AF0CC513"
-instantiate_entry_point_tx_hash = "89D30A44C93BB3B138731A653AE6D5AF7E5B3EFCF6A8A677C99B0293FD275910"
+store_swap_adapter_tx_hash = "a6a8fb7dff6ccad700565760797f5e170a06a5cf850f79c2f3ebcfb5dbecdc2f"
+store_ibc_transfer_adapter_tx_hash = "1fdc19f9770d02fe3482bb03e800af1464bb22aad2adf7da977e74d135a6eb3d"
+store_entry_point_tx_hash = "4adb5bb4a862e0932fcea4813e6edba01cc34d7a31e3ca428d2738442a1fbd49"
+instantiate_swap_adapter_tx_hash = "bcf206702d1cf4a1ce4f958e8e8f37357c86178f89c63c807e7dfb4a9a8e02d7"
+instantiate_ibc_transfer_adapter_tx_hash = "835b308267439c03d6f365553ff63d0e7b6a274f4c29931cff38622adcb37b58"
+instantiate_entry_point_tx_hash = "b24f5b2c9519d9051cd273abbc350b76b851675e763849eb8068f77bc9edc0a0"


### PR DESCRIPTION
## Background
- It was observed there was a bug in which our Astroport simulation queries can return results that are not able to be executed at the swap stage due to having a max_spread limit at swap which isn't taken into account on Astroport's queries.
- Relatedly, on the swap side we do not set a max_spread when we call the Astroport router contract, which defaults to a slippage limit of .005. This was decided to be changed to the max (.50) allowed on Astroport to reduce the amount of errors received from the Astroport contracts since our entry point handles the slippage we care about.

## This PR
Swap Side
1. Adds a max_spread amount of .50 (50%) to the Astroport router swaps, which is the max limit that can be set (Previously without setting this param, the max_spread defaulted to Astroport's default of .005)

Query Side:
1. Asserts the max spread limit is not crossed in both swap exact in and swap exact out simulation query for Astroport
2. Changes/refactors swap exact in simulation to call simulation query on each pool instead of the router (since the router doesn't return back enough info to assert the max spread limit calculation enforcement) for Astroport

- And deploys the contracts to terra

## Testing
1. Tested the new swap in query gives back the same result as the astroport router:
    - [swap adapter query](https://terrasco.pe/mainnet/address/terra1t8nee3950224v8uwhavpfvlfatjfjdmlmav8smwheme3d76np2rsl0xenz/smart/ewogICJzaW11bGF0ZV9zd2FwX2V4YWN0X2NvaW5faW4iOiB7CiAgICAiY29pbl9pbiI6IHsKICAgICAgImRlbm9tIjogImliYy8wNDcxRjFDNEU3QUZEM0YwNzcwMkJFRjZEQzM2NTI2OEQ2NDU3MEY3QzFGREM5OEVBNjA5OERENkRFNTk4MTdCIiwKICAgICAgImFtb3VudCI6ICIxMDAwMDAwIgogICAgfSwKICAgICJzd2FwX29wZXJhdGlvbnMiOiBbCiAgICAgIHsKICAgICAgICAicG9vbCI6ICJ0ZXJyYTFmdXZ6cTQ2cDJmd2hhNG1heDJjZW02NGwzcDJqdXlhdDRna2Z1cG41M2U4M3F6bjNqM21xdmcweWhrIiwKICAgICAgICAiZGVub21faW4iOiAiaWJjLzA0NzFGMUM0RTdBRkQzRjA3NzAyQkVGNkRDMzY1MjY4RDY0NTcwRjdDMUZEQzk4RUE2MDk4REQ2REU1OTgxN0IiLAogICAgICAgICJkZW5vbV9vdXQiOiAiaWJjL0IzNTA0RTA5MjQ1NkJBNjE4Q0MyOEFDNjcxQTcxRkIwOEM2Q0EwRkQwQkU3QzhBNUI1QTNFMkREOTMzQ0M5RTQiCiAgICAgIH0sCiAgICAgIHsKICAgICAgICAgICJwb29sIjogInRlcnJhMTNjdzQ2Zzcya3d0Z2xuMDU0MGo5Y3FhNzloYW01azg2amx4MzRlMnBxdWt3dzZ2MHYzeXNlYWtnZWQiLAogICAgICAgICAgImRlbm9tX2luIjogImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0IiwKICAgICAgICAgICJkZW5vbV9vdXQiOiAidWx1bmEiICAgICAgICAgCiAgICAgIH0gIAogICAgXQogIH0KfQ==)
    - [astroport router query](https://terrasco.pe/mainnet/address/terra1j8hayvehh3yy02c2vtw5fdhz9f4drhtee8p5n5rguvg3nyd6m83qd2y90a/smart/ewogICAgInNpbXVsYXRlX3N3YXBfb3BlcmF0aW9ucyI6IHsKICAgICAgICAib2ZmZXJfYW1vdW50IjogIjEwMDAwMDAiLAogICAgICAgICJvcGVyYXRpb25zIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiYXN0cm9fc3dhcCI6IHsKICAgICAgICAgICAgICAgICAgICAib2ZmZXJfYXNzZXRfaW5mbyI6IHsKICAgICAgICAgICAgICAgICAgICAgICAgIm5hdGl2ZV90b2tlbiI6IHsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICJkZW5vbSI6ICJpYmMvMDQ3MUYxQzRFN0FGRDNGMDc3MDJCRUY2REMzNjUyNjhENjQ1NzBGN0MxRkRDOThFQTYwOThERDZERTU5ODE3QiIKICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAgICAgImFza19hc3NldF9pbmZvIjogewogICAgICAgICAgICAgICAgICAgICAgICAibmF0aXZlX3Rva2VuIjogewogICAgICAgICAgICAgICAgICAgICAgICAgICAgImRlbm9tIjogImliYy9CMzUwNEUwOTI0NTZCQTYxOENDMjhBQzY3MUE3MUZCMDhDNkNBMEZEMEJFN0M4QTVCNUEzRTJERDkzM0NDOUU0IgogICAgICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9LAogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAiYXN0cm9fc3dhcCI6IHsKICAgICAgICAgICAgICAgICAgICAib2ZmZXJfYXNzZXRfaW5mbyI6IHsKICAgICAgICAgICAgICAgICAgICAgICAgIm5hdGl2ZV90b2tlbiI6IHsKICAgICAgICAgICAgICAgICAgICAgICAgICAgICJkZW5vbSI6ICJpYmMvQjM1MDRFMDkyNDU2QkE2MThDQzI4QUM2NzFBNzFGQjA4QzZDQTBGRDBCRTdDOEE1QjVBM0UyREQ5MzNDQzlFNCIKICAgICAgICAgICAgICAgICAgICAgICAgfQogICAgICAgICAgICAgICAgICAgIH0sCiAgICAgICAgICAgICAgICAgICAgImFza19hc3NldF9pbmZvIjogewogICAgICAgICAgICAgICAgICAgICAgICAibmF0aXZlX3Rva2VuIjogewogICAgICAgICAgICAgICAgICAgICAgICAgICAgImRlbm9tIjogInVsdW5hIiAgICAgICAgCiAgICAgICAgICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgICAgICB9CiAgICAgICAgICAgIH0KICAgICAgICBdCiAgICB9Cn0=)
4. Tested that the max_spread_assertion query fails when expected
5. Tested a successful swap tx that was previously failing with an error of max slippage limit crossed: https://www.mintscan.io/osmosis/tx/4867E0A4914F90CB6F97406406B8F67B3D8A44AF845BC090ACDFCFE2A3B4F246?height=12288371