### PR TITLE
Add Spot Price In Swap Simulation Query Responses

### DIFF
--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -384,8 +384,8 @@ fn query_simulate_swap_exact_asset_in_with_spot_price(
             Ok((
                 Asset::new(deps.api, &operation.denom_out, res.return_amount),
                 curr_spot_price.checked_mul(Decimal::from_ratio(
-                    asset_out.amount(),
                     amount_out_without_slippage,
+                    asset_out.amount(),
                 ))?,
             ))
         },
@@ -447,8 +447,8 @@ fn query_simulate_swap_exact_asset_out_with_spot_price(
                     res.offer_amount.checked_add(Uint128::one())?,
                 ),
                 curr_spot_price.checked_mul(Decimal::from_ratio(
-                    res.offer_amount,
                     amount_out_without_slippage,
+                    res.offer_amount,
                 ))?,
             ))
         },

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -278,14 +278,14 @@ fn query_simulate_swap_exact_asset_out(
         return Err(ContractError::SwapOperationsEmpty);
     };
 
-    // Ensure coin_out's denom is the same as the last swap operation's denom out
+    // Ensure asset_out's denom is the same as the last swap operation's denom out
     if asset_out.denom() != last_op.denom_out {
         return Err(ContractError::CoinOutDenomMismatch);
     }
 
     let (asset_in, _) = simulate_swap_exact_asset_out(deps, asset_out, swap_operations, false)?;
 
-    // Return the coin in needed
+    // Return the asset in needed
     Ok(asset_in)
 }
 
@@ -351,7 +351,7 @@ fn query_simulate_swap_exact_asset_out_with_metadata(
         return Err(ContractError::SwapOperationsEmpty);
     };
 
-    // Ensure coin_out's denom is the same as the last swap operation's denom out
+    // Ensure asset_out's denom is the same as the last swap operation's denom out
     if asset_out.denom() != last_op.denom_out {
         return Err(ContractError::CoinOutDenomMismatch);
     }

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -221,18 +221,18 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             asset_out,
             swap_operations,
         )?),
-        QueryMsg::SimulateSwapExactAssetInWithSpotPrice {
+        QueryMsg::SimulateSwapExactAssetInWithMetadata {
             asset_in,
             swap_operations,
-        } => to_binary(&query_simulate_swap_exact_asset_in_with_spot_price(
+        } => to_binary(&query_simulate_swap_exact_asset_in_with_metadata(
             deps,
             asset_in,
             swap_operations,
         )?),
-        QueryMsg::SimulateSwapExactAssetOutWithSpotPrice {
+        QueryMsg::SimulateSwapExactAssetOutWithMetadata {
             asset_out,
             swap_operations,
-        } => to_binary(&query_simulate_swap_exact_asset_out_with_spot_price(
+        } => to_binary(&query_simulate_swap_exact_asset_out_with_metadata(
             deps,
             asset_out,
             swap_operations,
@@ -339,8 +339,8 @@ fn query_simulate_swap_exact_asset_out(
     Ok(asset_in_needed)
 }
 
-// Queries the astroport router contract to simulate a swap exact amount in with spot price
-fn query_simulate_swap_exact_asset_in_with_spot_price(
+// Queries the astroport router contract to simulate a swap exact amount in with metadata
+fn query_simulate_swap_exact_asset_in_with_metadata(
     deps: Deps,
     asset_in: Asset,
     swap_operations: Vec<SwapOperation>,
@@ -393,12 +393,12 @@ fn query_simulate_swap_exact_asset_in_with_spot_price(
 
     Ok(SimulateSwapExactAssetInResponse {
         asset_out,
-        spot_price,
+        spot_price: Some(spot_price),
     })
 }
 
-// Queries the astroport pool contracts to simulate a multi-hop swap exact amount out with spot price
-fn query_simulate_swap_exact_asset_out_with_spot_price(
+// Queries the astroport pool contracts to simulate a multi-hop swap exact amount out with metadata
+fn query_simulate_swap_exact_asset_out_with_metadata(
     deps: Deps,
     asset_out: Asset,
     swap_operations: Vec<SwapOperation>,
@@ -456,7 +456,7 @@ fn query_simulate_swap_exact_asset_out_with_spot_price(
 
     Ok(SimulateSwapExactAssetOutResponse {
         asset_in,
-        spot_price,
+        spot_price: Some(spot_price),
     })
 }
 

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -224,18 +224,22 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
         QueryMsg::SimulateSwapExactAssetInWithMetadata {
             asset_in,
             swap_operations,
+            include_spot_price,
         } => to_binary(&query_simulate_swap_exact_asset_in_with_metadata(
             deps,
             asset_in,
             swap_operations,
+            include_spot_price,
         )?),
         QueryMsg::SimulateSwapExactAssetOutWithMetadata {
             asset_out,
             swap_operations,
+            include_spot_price,
         } => to_binary(&query_simulate_swap_exact_asset_out_with_metadata(
             deps,
             asset_out,
             swap_operations,
+            include_spot_price,
         )?),
     }
     .map_err(From::from)
@@ -257,34 +261,7 @@ fn query_simulate_swap_exact_asset_in(
         return Err(ContractError::CoinInDenomMismatch);
     }
 
-    // Iterate through the swap operations, querying the astroport pool contracts to get the asset out
-    // for each swap operation, and then updating the asset out for the next swap operation until the
-    // asset out for the last swap operation is found.
-    let asset_out = swap_operations.iter().try_fold(
-        asset_in,
-        |asset_out, operation| -> Result<_, ContractError> {
-            // Get the astroport offer asset type
-            let astroport_offer_asset = asset_out.into_astroport_asset(deps.api)?;
-
-            // Query the astroport pool contract to get the coin out for the swap operation
-            let res: SimulationResponse = deps.querier.query_wasm_smart(
-                &operation.pool,
-                &PairQueryMsg::Simulation {
-                    offer_asset: astroport_offer_asset,
-                    ask_asset_info: None,
-                },
-            )?;
-
-            // Assert the operation does not exceed the max spread limit
-            assert_max_spread(res.return_amount, res.spread_amount)?;
-
-            Ok(Asset::new(
-                deps.api,
-                &operation.denom_out,
-                res.return_amount,
-            ))
-        },
-    )?;
+    let (asset_out, _) = simulate_swap_exact_asset_in(deps, asset_in, swap_operations, false)?;
 
     // Return the asset out
     Ok(asset_out)
@@ -306,37 +283,10 @@ fn query_simulate_swap_exact_asset_out(
         return Err(ContractError::CoinOutDenomMismatch);
     }
 
-    // Iterate through the swap operations in reverse order, querying the astroport pool contracts
-    // contracts to get the asset in needed for each swap operation, and then updating the asset in
-    // needed for the next swap operation until the asset in needed for the first swap operation is found.
-    let asset_in_needed = swap_operations.iter().rev().try_fold(
-        asset_out,
-        |asset_in_needed, operation| -> Result<Asset, ContractError> {
-            // Get the astroport ask asset type
-            let astroport_ask_asset = asset_in_needed.into_astroport_asset(deps.api)?;
-
-            // Query the astroport pool contract to get the coin in needed for the swap operation
-            let res: ReverseSimulationResponse = deps.querier.query_wasm_smart(
-                &operation.pool,
-                &PairQueryMsg::ReverseSimulation {
-                    offer_asset_info: None,
-                    ask_asset: astroport_ask_asset,
-                },
-            )?;
-
-            // Assert the operation does not exceed the max spread limit
-            assert_max_spread(res.offer_amount, res.spread_amount)?;
-
-            Ok(Asset::new(
-                deps.api,
-                &operation.denom_in,
-                res.offer_amount.checked_add(Uint128::one())?,
-            ))
-        },
-    )?;
+    let (asset_in, _) = simulate_swap_exact_asset_out(deps, asset_out, swap_operations, false)?;
 
     // Return the coin in needed
-    Ok(asset_in_needed)
+    Ok(asset_in)
 }
 
 // Queries the astroport router contract to simulate a swap exact amount in with metadata
@@ -344,6 +294,7 @@ fn query_simulate_swap_exact_asset_in_with_metadata(
     deps: Deps,
     asset_in: Asset,
     swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
 ) -> ContractResult<SimulateSwapExactAssetInResponse> {
     // Error if swap operations is empty
     let Some(first_op) = swap_operations.first() else {
@@ -355,11 +306,107 @@ fn query_simulate_swap_exact_asset_in_with_metadata(
         return Err(ContractError::CoinInDenomMismatch);
     }
 
-    // Iterate through the swap operations, querying the astroport pool contracts to get the asset out
-    // and spot price for each swap operation, and then updating the asset out and spot price until finished iterating.
-    let (asset_out, spot_price) = swap_operations.iter().try_fold(
-        (asset_in, Decimal::one()),
-        |(asset_out, curr_spot_price), operation| -> Result<_, ContractError> {
+    // Determine if we should request the simulation responses from simulate_swap_exact_asset_in
+    let mut include_sim_resps = false;
+    if include_spot_price {
+        include_sim_resps = true;
+    }
+
+    // Simulate the swap exact amount in
+    let (asset_out, sim_resps) = simulate_swap_exact_asset_in(
+        deps,
+        asset_in.clone(),
+        swap_operations.clone(),
+        include_sim_resps,
+    )?;
+
+    // Create the response
+    let mut response = SimulateSwapExactAssetInResponse {
+        asset_out,
+        spot_price: None,
+    };
+
+    // Include the spot price in the response if requested
+    if include_spot_price {
+        response.spot_price = Some(calculate_spot_price_from_simulation_responses(
+            deps,
+            asset_in,
+            swap_operations,
+            sim_resps,
+        )?)
+    }
+
+    Ok(response)
+}
+
+// Queries the astroport pool contracts to simulate a multi-hop swap exact amount out with metadata
+fn query_simulate_swap_exact_asset_out_with_metadata(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_spot_price: bool,
+) -> ContractResult<SimulateSwapExactAssetOutResponse> {
+    // Error if swap operations is empty
+    let Some(last_op) = swap_operations.last() else {
+        return Err(ContractError::SwapOperationsEmpty);
+    };
+
+    // Ensure coin_out's denom is the same as the last swap operation's denom out
+    if asset_out.denom() != last_op.denom_out {
+        return Err(ContractError::CoinOutDenomMismatch);
+    }
+
+    // Determine if we should request the simulation responses from simulate_swap_exact_asset_out
+    let mut include_sim_resps = false;
+    if include_spot_price {
+        include_sim_resps = true;
+    }
+
+    // Simulate the swap exact amount out
+    let (asset_in, sim_resps) = simulate_swap_exact_asset_out(
+        deps,
+        asset_out.clone(),
+        swap_operations.clone(),
+        include_sim_resps,
+    )?;
+
+    // Create the response
+    let mut response = SimulateSwapExactAssetOutResponse {
+        asset_in,
+        spot_price: None,
+    };
+
+    // Include the spot price in the response if requested
+    if include_spot_price {
+        response.spot_price = Some(calculate_spot_price_from_reverse_simulation_responses(
+            deps,
+            asset_out,
+            swap_operations,
+            sim_resps,
+        )?)
+    }
+
+    Ok(response)
+}
+
+fn assert_max_spread(return_amount: Uint128, spread_amount: Uint128) -> ContractResult<()> {
+    let max_spread = MAX_ALLOWED_SLIPPAGE.parse::<Decimal>()?;
+    if Decimal::from_ratio(spread_amount, return_amount + spread_amount) > max_spread {
+        return Err(ContractError::MaxSpreadAssertion {});
+    }
+    Ok(())
+}
+
+// Simulates a swap exact amount in request, returning the asset out and optionally the reverse simulation responses
+fn simulate_swap_exact_asset_in(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    include_responses: bool,
+) -> ContractResult<(Asset, Vec<SimulationResponse>)> {
+    let (asset_out, responses) = swap_operations.iter().try_fold(
+        (asset_in, Vec::new()),
+        |(asset_out, mut responses), operation| -> Result<_, ContractError> {
             // Get the astroport offer asset type
             let astroport_offer_asset = asset_out.into_astroport_asset(deps.api)?;
 
@@ -375,50 +422,30 @@ fn query_simulate_swap_exact_asset_in_with_metadata(
             // Assert the operation does not exceed the max spread limit
             assert_max_spread(res.return_amount, res.spread_amount)?;
 
-            // Calculate the amount out without slippage
-            let amount_out_without_slippage = res
-                .return_amount
-                .checked_add(res.spread_amount)?
-                .checked_add(res.commission_amount)?;
+            if include_responses {
+                responses.push(res.clone());
+            }
 
             Ok((
                 Asset::new(deps.api, &operation.denom_out, res.return_amount),
-                curr_spot_price.checked_mul(Decimal::from_ratio(
-                    amount_out_without_slippage,
-                    asset_out.amount(),
-                ))?,
+                responses,
             ))
         },
     )?;
 
-    Ok(SimulateSwapExactAssetInResponse {
-        asset_out,
-        spot_price: Some(spot_price),
-    })
+    Ok((asset_out, responses))
 }
 
-// Queries the astroport pool contracts to simulate a multi-hop swap exact amount out with metadata
-fn query_simulate_swap_exact_asset_out_with_metadata(
+// Simulates a swap exact amount out request, returning the asset in needed and optionally the reverse simulation responses
+fn simulate_swap_exact_asset_out(
     deps: Deps,
     asset_out: Asset,
     swap_operations: Vec<SwapOperation>,
-) -> ContractResult<SimulateSwapExactAssetOutResponse> {
-    // Error if swap operations is empty
-    let Some(last_op) = swap_operations.last() else {
-        return Err(ContractError::SwapOperationsEmpty);
-    };
-
-    // Ensure coin_out's denom is the same as the last swap operation's denom out
-    if asset_out.denom() != last_op.denom_out {
-        return Err(ContractError::CoinOutDenomMismatch);
-    }
-
-    // Iterate through the swap operations in reverse order, querying the astroport pool contracts
-    // to get the asset in and spot price for each swap operation, and then updating the asset in
-    // and spot price until finished iterating.
-    let (asset_in, spot_price) = swap_operations.iter().rev().try_fold(
-        (asset_out, Decimal::one()),
-        |(asset_in_needed, curr_spot_price), operation| -> Result<_, ContractError> {
+    include_responses: bool,
+) -> ContractResult<(Asset, Vec<ReverseSimulationResponse>)> {
+    let (asset_in, responses) = swap_operations.iter().rev().try_fold(
+        (asset_out, Vec::new()),
+        |(asset_in_needed, mut responses), operation| -> Result<_, ContractError> {
             // Get the astroport ask asset type
             let astroport_ask_asset = asset_in_needed.into_astroport_asset(deps.api)?;
 
@@ -434,11 +461,9 @@ fn query_simulate_swap_exact_asset_out_with_metadata(
             // Assert the operation does not exceed the max spread limit
             assert_max_spread(res.offer_amount, res.spread_amount)?;
 
-            // Calculate the amount out without slippage
-            let amount_out_without_slippage = asset_in_needed
-                .amount()
-                .checked_add(res.spread_amount)?
-                .checked_add(res.commission_amount)?;
+            if include_responses {
+                responses.push(res.clone());
+            }
 
             Ok((
                 Asset::new(
@@ -446,24 +471,75 @@ fn query_simulate_swap_exact_asset_out_with_metadata(
                     &operation.denom_in,
                     res.offer_amount.checked_add(Uint128::one())?,
                 ),
+                responses,
+            ))
+        },
+    )?;
+
+    Ok((asset_in, responses))
+}
+
+// Calculate the spot price using simulation responses
+fn calculate_spot_price_from_simulation_responses(
+    deps: Deps,
+    asset_in: Asset,
+    swap_operations: Vec<SwapOperation>,
+    simulation_responses: Vec<SimulationResponse>,
+) -> ContractResult<Decimal> {
+    let (_, spot_price) = swap_operations.iter().zip(simulation_responses).try_fold(
+        (asset_in, Decimal::one()),
+        |(asset_out, curr_spot_price), (op, res)| -> Result<_, ContractError> {
+            // Calculate the amount out without slippage
+            let amount_out_without_slippage = res
+                .return_amount
+                .checked_add(res.spread_amount)?
+                .checked_add(res.commission_amount)?;
+
+            Ok((
+                Asset::new(deps.api, &op.denom_out, res.return_amount),
                 curr_spot_price.checked_mul(Decimal::from_ratio(
                     amount_out_without_slippage,
-                    res.offer_amount,
+                    asset_out.amount(),
                 ))?,
             ))
         },
     )?;
 
-    Ok(SimulateSwapExactAssetOutResponse {
-        asset_in,
-        spot_price: Some(spot_price),
-    })
+    Ok(spot_price)
 }
 
-fn assert_max_spread(return_amount: Uint128, spread_amount: Uint128) -> ContractResult<()> {
-    let max_spread = MAX_ALLOWED_SLIPPAGE.parse::<Decimal>()?;
-    if Decimal::from_ratio(spread_amount, return_amount + spread_amount) > max_spread {
-        return Err(ContractError::MaxSpreadAssertion {});
-    }
-    Ok(())
+// Calculates the spot price using reverse simulaation responses
+fn calculate_spot_price_from_reverse_simulation_responses(
+    deps: Deps,
+    asset_out: Asset,
+    swap_operations: Vec<SwapOperation>,
+    reverse_simulation_responses: Vec<ReverseSimulationResponse>,
+) -> ContractResult<Decimal> {
+    let (_, spot_price) = swap_operations
+        .iter()
+        .rev()
+        .zip(reverse_simulation_responses)
+        .try_fold(
+            (asset_out, Decimal::one()),
+            |(asset_in_needed, curr_spot_price), (op, res)| -> Result<_, ContractError> {
+                let amount_out_without_slippage = asset_in_needed
+                    .amount()
+                    .checked_add(res.spread_amount)?
+                    .checked_add(res.commission_amount)?;
+
+                Ok((
+                    Asset::new(
+                        deps.api,
+                        &op.denom_in,
+                        res.offer_amount.checked_add(Uint128::one())?,
+                    ),
+                    curr_spot_price.checked_mul(Decimal::from_ratio(
+                        amount_out_without_slippage,
+                        res.offer_amount,
+                    ))?,
+                ))
+            },
+        )?;
+
+    Ok(spot_price)
 }

--- a/contracts/adapters/swap/lido-satellite/src/contract.rs
+++ b/contracts/adapters/swap/lido-satellite/src/contract.rs
@@ -166,68 +166,72 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
 
     match msg {
         QueryMsg::SimulateSwapExactAssetIn { asset_in, .. } => {
-            if asset_in.denom() == bridged_denom {
-                to_binary(&Asset::Native(Coin::new(
-                    asset_in.amount().u128(),
-                    canonical_denom,
-                )))
-            } else if asset_in.denom() == canonical_denom {
-                to_binary(&Asset::Native(Coin::new(
-                    asset_in.amount().u128(),
-                    bridged_denom,
-                )))
-            } else {
-                unimplemented!()
-            }
+            let asset_out_denom =
+                get_opposite_denom(asset_in.denom(), &bridged_denom, &canonical_denom);
+
+            to_binary(&Asset::Native(Coin::new(
+                asset_in.amount().u128(),
+                asset_out_denom,
+            )))
         }
         QueryMsg::SimulateSwapExactAssetOut { asset_out, .. } => {
-            if asset_out.denom() == bridged_denom {
-                to_binary(&Asset::Native(Coin::new(
-                    asset_out.amount().u128(),
-                    canonical_denom,
-                )))
-            } else if asset_out.denom() == canonical_denom {
-                to_binary(&Asset::Native(Coin::new(
-                    asset_out.amount().u128(),
-                    bridged_denom,
-                )))
-            } else {
-                unimplemented!()
-            }
+            let asset_in_denom =
+                get_opposite_denom(asset_out.denom(), &bridged_denom, &canonical_denom);
+
+            to_binary(&Asset::Native(Coin::new(
+                asset_out.amount().u128(),
+                asset_in_denom,
+            )))
         }
-        QueryMsg::SimulateSwapExactAssetInWithMetadata { asset_in, .. } => {
-            if asset_in.denom() == bridged_denom {
-                to_binary(&SimulateSwapExactAssetInResponse {
-                    asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), canonical_denom)),
-                    spot_price: Some(Decimal::one()),
-                })
-            } else if asset_in.denom() == canonical_denom {
-                to_binary(&SimulateSwapExactAssetInResponse {
-                    asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), bridged_denom)),
-                    spot_price: Some(Decimal::one()),
-                })
+        QueryMsg::SimulateSwapExactAssetInWithMetadata {
+            asset_in,
+            include_spot_price,
+            ..
+        } => {
+            let asset_out_denom =
+                get_opposite_denom(asset_in.denom(), &bridged_denom, &canonical_denom);
+
+            let spot_price = if include_spot_price {
+                Some(Decimal::one())
             } else {
-                unimplemented!()
-            }
+                None
+            };
+
+            to_binary(&SimulateSwapExactAssetInResponse {
+                asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), asset_out_denom)),
+                spot_price,
+            })
         }
-        QueryMsg::SimulateSwapExactAssetOutWithMetadata { asset_out, .. } => {
-            if asset_out.denom() == bridged_denom {
-                to_binary(&SimulateSwapExactAssetOutResponse {
-                    asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), canonical_denom)),
-                    spot_price: Some(Decimal::one()),
-                })
-            } else if asset_out.denom() == canonical_denom {
-                to_binary(&SimulateSwapExactAssetOutResponse {
-                    asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), bridged_denom)),
-                    spot_price: Some(Decimal::one()),
-                })
+        QueryMsg::SimulateSwapExactAssetOutWithMetadata {
+            asset_out,
+            include_spot_price,
+            ..
+        } => {
+            let asset_in_denom =
+                get_opposite_denom(asset_out.denom(), &bridged_denom, &canonical_denom);
+
+            let spot_price = if include_spot_price {
+                Some(Decimal::one())
             } else {
-                unimplemented!()
-            }
+                None
+            };
+
+            to_binary(&SimulateSwapExactAssetOutResponse {
+                asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), asset_in_denom)),
+                spot_price,
+            })
         }
         _ => {
             unimplemented!()
         }
     }
     .map_err(From::from)
+}
+
+fn get_opposite_denom(denom: &str, bridged_denom: &str, canonical_denom: &str) -> String {
+    match denom {
+        denom if denom == bridged_denom => canonical_denom.to_string(),
+        denom if denom == canonical_denom => bridged_denom.to_string(),
+        _ => unimplemented!(),
+    }
 }

--- a/contracts/adapters/swap/lido-satellite/src/contract.rs
+++ b/contracts/adapters/swap/lido-satellite/src/contract.rs
@@ -6,14 +6,16 @@ use crate::{
     },
 };
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Coin, Deps, DepsMut, Env, MessageInfo, Response, WasmMsg,
+    entry_point, to_binary, Binary, Coin, Decimal, Deps, DepsMut, Env, MessageInfo, Response,
+    WasmMsg,
 };
 use cw_utils::one_coin;
 use skip::{
     asset::Asset,
     swap::{
         execute_transfer_funds_back, ExecuteMsg, LidoSatelliteInstantiateMsg as InstantiateMsg,
-        QueryMsg, SwapOperation,
+        QueryMsg, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse,
+        SwapOperation,
     },
 };
 
@@ -189,6 +191,36 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
                     asset_out.amount().u128(),
                     bridged_denom,
                 )))
+            } else {
+                unimplemented!()
+            }
+        }
+        QueryMsg::SimulateSwapExactAssetInWithSpotPrice { asset_in, .. } => {
+            if asset_in.denom() == bridged_denom {
+                to_binary(&SimulateSwapExactAssetInResponse {
+                    asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), canonical_denom)),
+                    spot_price: Decimal::one(),
+                })
+            } else if asset_in.denom() == canonical_denom {
+                to_binary(&SimulateSwapExactAssetInResponse {
+                    asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), bridged_denom)),
+                    spot_price: Decimal::one(),
+                })
+            } else {
+                unimplemented!()
+            }
+        }
+        QueryMsg::SimulateSwapExactAssetOutWithSpotPrice { asset_out, .. } => {
+            if asset_out.denom() == bridged_denom {
+                to_binary(&SimulateSwapExactAssetOutResponse {
+                    asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), canonical_denom)),
+                    spot_price: Decimal::one(),
+                })
+            } else if asset_out.denom() == canonical_denom {
+                to_binary(&SimulateSwapExactAssetOutResponse {
+                    asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), bridged_denom)),
+                    spot_price: Decimal::one(),
+                })
             } else {
                 unimplemented!()
             }

--- a/contracts/adapters/swap/lido-satellite/src/contract.rs
+++ b/contracts/adapters/swap/lido-satellite/src/contract.rs
@@ -195,31 +195,31 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
                 unimplemented!()
             }
         }
-        QueryMsg::SimulateSwapExactAssetInWithSpotPrice { asset_in, .. } => {
+        QueryMsg::SimulateSwapExactAssetInWithMetadata { asset_in, .. } => {
             if asset_in.denom() == bridged_denom {
                 to_binary(&SimulateSwapExactAssetInResponse {
                     asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), canonical_denom)),
-                    spot_price: Decimal::one(),
+                    spot_price: Some(Decimal::one()),
                 })
             } else if asset_in.denom() == canonical_denom {
                 to_binary(&SimulateSwapExactAssetInResponse {
                     asset_out: Asset::Native(Coin::new(asset_in.amount().u128(), bridged_denom)),
-                    spot_price: Decimal::one(),
+                    spot_price: Some(Decimal::one()),
                 })
             } else {
                 unimplemented!()
             }
         }
-        QueryMsg::SimulateSwapExactAssetOutWithSpotPrice { asset_out, .. } => {
+        QueryMsg::SimulateSwapExactAssetOutWithMetadata { asset_out, .. } => {
             if asset_out.denom() == bridged_denom {
                 to_binary(&SimulateSwapExactAssetOutResponse {
                     asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), canonical_denom)),
-                    spot_price: Decimal::one(),
+                    spot_price: Some(Decimal::one()),
                 })
             } else if asset_out.denom() == canonical_denom {
                 to_binary(&SimulateSwapExactAssetOutResponse {
                     asset_in: Asset::Native(Coin::new(asset_out.amount().u128(), bridged_denom)),
-                    spot_price: Decimal::one(),
+                    spot_price: Some(Decimal::one()),
                 })
             } else {
                 unimplemented!()

--- a/contracts/adapters/swap/lido-satellite/src/contract.rs
+++ b/contracts/adapters/swap/lido-satellite/src/contract.rs
@@ -99,7 +99,6 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    // FIXME: seems like we are doomed to ignore this field at all?
     _operations: Vec<SwapOperation>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage

--- a/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
@@ -3,20 +3,21 @@ use crate::{
     state::ENTRY_POINT_CONTRACT_ADDRESS,
 };
 use cosmwasm_std::{
-    entry_point, to_binary, Binary, Coin, CosmosMsg, Deps, DepsMut, Env, MessageInfo, Response,
-    Uint128, WasmMsg,
+    entry_point, to_binary, Binary, Coin, CosmosMsg, Decimal, Deps, DepsMut, Empty, Env,
+    MessageInfo, Response, Uint128, WasmMsg,
 };
 use cw_utils::one_coin;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
     EstimateSwapExactAmountInResponse, EstimateSwapExactAmountOutResponse, MsgSwapExactAmountIn,
-    PoolmanagerQuerier, SwapAmountInRoute, SwapAmountOutRoute,
+    PoolmanagerQuerier, SpotPriceResponse, SwapAmountInRoute, SwapAmountOutRoute,
 };
 use skip::{
     asset::Asset,
     proto_coin::ProtoCoin,
     swap::{
         convert_swap_operations, execute_transfer_funds_back, ExecuteMsg,
-        OsmosisInstantiateMsg as InstantiateMsg, QueryMsg, SwapOperation,
+        OsmosisInstantiateMsg as InstantiateMsg, QueryMsg, SimulateSwapExactAssetInResponse,
+        SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 use std::str::FromStr;
@@ -184,7 +185,7 @@ fn query_simulate_swap_exact_asset_in(
     deps: Deps,
     asset_in: Asset,
     swap_operations: Vec<SwapOperation>,
-) -> ContractResult<Asset> {
+) -> ContractResult<SimulateSwapExactAssetInResponse> {
     // Error if swap operations is empty
     let (Some(first_op), Some(last_op)) = (swap_operations.first(), swap_operations.last()) else {
         return Err(ContractError::SwapOperationsEmpty);
@@ -209,22 +210,26 @@ fn query_simulate_swap_exact_asset_in(
     // Return an error if there was an error converting the swap
     // operations to osmosis swap amount in routes.
     let osmosis_swap_amount_in_routes: Vec<SwapAmountInRoute> =
-        convert_swap_operations(swap_operations).map_err(ContractError::ParseIntPoolID)?;
+        convert_swap_operations(swap_operations.clone()).map_err(ContractError::ParseIntPoolID)?;
+
+    let poolmanager_querier = PoolmanagerQuerier::new(&deps.querier);
 
     // Query the osmosis poolmanager module to simulate the swap exact amount in
-    let res: EstimateSwapExactAmountInResponse = PoolmanagerQuerier::new(&deps.querier)
+    let res: EstimateSwapExactAmountInResponse = poolmanager_querier
         .estimate_swap_exact_amount_in(
             osmosis_swap_amount_in_routes.first().unwrap().pool_id,
             coin_in.to_string(),
-            osmosis_swap_amount_in_routes,
+            osmosis_swap_amount_in_routes.clone(),
         )?;
 
-    // Return the coin out
-    Ok(Coin {
-        denom: denom_out,
-        amount: Uint128::from_str(&res.token_out_amount)?,
-    }
-    .into())
+    Ok(SimulateSwapExactAssetInResponse {
+        asset_out: Coin {
+            denom: denom_out,
+            amount: Uint128::from_str(&res.token_out_amount)?,
+        }
+        .into(),
+        spot_price: calculate_spot_price(&poolmanager_querier, swap_operations)?,
+    })
 }
 
 // Queries the osmosis poolmanager module to simulate a swap exact amount out
@@ -232,7 +237,7 @@ fn query_simulate_swap_exact_asset_out(
     deps: Deps,
     asset_out: Asset,
     swap_operations: Vec<SwapOperation>,
-) -> ContractResult<Asset> {
+) -> ContractResult<SimulateSwapExactAssetOutResponse> {
     // Error if swap operations is empty
     let (Some(first_op), Some(last_op)) = (swap_operations.first(), swap_operations.last()) else {
         return Err(ContractError::SwapOperationsEmpty);
@@ -257,20 +262,45 @@ fn query_simulate_swap_exact_asset_out(
     // Return an error if there was an error converting the swap
     // operations to osmosis swap amount out routes.
     let osmosis_swap_amount_out_routes: Vec<SwapAmountOutRoute> =
-        convert_swap_operations(swap_operations).map_err(ContractError::ParseIntPoolID)?;
+        convert_swap_operations(swap_operations.clone()).map_err(ContractError::ParseIntPoolID)?;
+
+    // Create the osmosis poolmanager querier
+    let poolmanager_querier = PoolmanagerQuerier::new(&deps.querier);
 
     // Query the osmosis poolmanager module to simulate the swap exact amount out
-    let res: EstimateSwapExactAmountOutResponse = PoolmanagerQuerier::new(&deps.querier)
+    let res: EstimateSwapExactAmountOutResponse = poolmanager_querier
         .estimate_swap_exact_amount_out(
             osmosis_swap_amount_out_routes.first().unwrap().pool_id,
             osmosis_swap_amount_out_routes,
             coin_out.to_string(),
         )?;
 
-    // Return the coin in needed
-    Ok(Coin {
-        denom: denom_in,
-        amount: Uint128::from_str(&res.token_in_amount)?,
-    }
-    .into())
+    Ok(SimulateSwapExactAssetOutResponse {
+        asset_in: Coin {
+            denom: denom_in,
+            amount: Uint128::from_str(&res.token_in_amount)?,
+        }
+        .into(),
+        spot_price: calculate_spot_price(&poolmanager_querier, swap_operations)?,
+    })
+}
+
+// Calculates the spot price for a given vector of swap operations
+fn calculate_spot_price(
+    querier: &PoolmanagerQuerier<Empty>,
+    swap_operations: Vec<SwapOperation>,
+) -> ContractResult<Decimal> {
+    let spot_price = swap_operations.into_iter().try_fold(
+        Decimal::one(),
+        |curr_spot_price, swap_op| -> ContractResult<Decimal> {
+            let spot_price_res: SpotPriceResponse = querier.spot_price(
+                swap_op.pool.parse()?, // should not error since we already parsed it earlier
+                swap_op.denom_in,
+                swap_op.denom_out,
+            )?;
+            Ok(curr_spot_price.checked_mul(Decimal::from_str(&spot_price_res.spot_price)?)?)
+        },
+    )?;
+
+    Ok(spot_price)
 }

--- a/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
@@ -240,7 +240,7 @@ fn query_simulate_swap_exact_asset_in(
             osmosis_swap_amount_in_routes,
         )?;
 
-    // Return the coin out
+    // Return the asset out
     Ok(Coin {
         denom: denom_out,
         amount: Uint128::from_str(&res.token_out_amount)?,
@@ -288,7 +288,7 @@ fn query_simulate_swap_exact_asset_out(
             coin_out.to_string(),
         )?;
 
-    // Return the coin in needed
+    // Return the asset in needed
     Ok(Coin {
         denom: denom_in,
         amount: Uint128::from_str(&res.token_in_amount)?,

--- a/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
@@ -173,18 +173,18 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> ContractResult<Binary> {
             asset_out,
             swap_operations,
         )?),
-        QueryMsg::SimulateSwapExactAssetInWithSpotPrice {
+        QueryMsg::SimulateSwapExactAssetInWithMetadata {
             asset_in,
             swap_operations,
-        } => to_binary(&query_simulate_swap_exact_asset_in_with_spot_price(
+        } => to_binary(&query_simulate_swap_exact_asset_in_with_metadata(
             deps,
             asset_in,
             swap_operations,
         )?),
-        QueryMsg::SimulateSwapExactAssetOutWithSpotPrice {
+        QueryMsg::SimulateSwapExactAssetOutWithMetadata {
             asset_out,
             swap_operations,
-        } => to_binary(&query_simulate_swap_exact_asset_out_with_spot_price(
+        } => to_binary(&query_simulate_swap_exact_asset_out_with_metadata(
             deps,
             asset_out,
             swap_operations,
@@ -292,27 +292,33 @@ fn query_simulate_swap_exact_asset_out(
     .into())
 }
 
-// Queries the osmosis poolmanager module to simulate a swap exact amount in with spot price
-fn query_simulate_swap_exact_asset_in_with_spot_price(
+// Queries the osmosis poolmanager module to simulate a swap exact amount in with metadata
+fn query_simulate_swap_exact_asset_in_with_metadata(
     deps: Deps,
     asset_in: Asset,
     swap_operations: Vec<SwapOperation>,
 ) -> ContractResult<SimulateSwapExactAssetInResponse> {
     Ok(SimulateSwapExactAssetInResponse {
         asset_out: query_simulate_swap_exact_asset_in(deps, asset_in, swap_operations.clone())?,
-        spot_price: calculate_spot_price(&PoolmanagerQuerier::new(&deps.querier), swap_operations)?,
+        spot_price: Some(calculate_spot_price(
+            &PoolmanagerQuerier::new(&deps.querier),
+            swap_operations,
+        )?),
     })
 }
 
-// Queries the osmosis poolmanager module to simulate a swap exact amount out with spot price
-fn query_simulate_swap_exact_asset_out_with_spot_price(
+// Queries the osmosis poolmanager module to simulate a swap exact amount out with metadata
+fn query_simulate_swap_exact_asset_out_with_metadata(
     deps: Deps,
     asset_out: Asset,
     swap_operations: Vec<SwapOperation>,
 ) -> ContractResult<SimulateSwapExactAssetOutResponse> {
     Ok(SimulateSwapExactAssetOutResponse {
         asset_in: query_simulate_swap_exact_asset_out(deps, asset_out, swap_operations.clone())?,
-        spot_price: calculate_spot_price(&PoolmanagerQuerier::new(&deps.querier), swap_operations)?,
+        spot_price: Some(calculate_spot_price(
+            &PoolmanagerQuerier::new(&deps.querier),
+            swap_operations,
+        )?),
     })
 }
 

--- a/contracts/adapters/swap/osmosis-poolmanager/src/error.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/error.rs
@@ -15,12 +15,6 @@ pub enum ContractError {
     #[error(transparent)]
     Payment(#[from] cw_utils::PaymentError),
 
-    #[error(transparent)]
-    Decimal(#[from] cosmwasm_std::DecimalRangeExceeded),
-
-    #[error(transparent)]
-    Overflow(#[from] cosmwasm_std::OverflowError),
-
     #[error("Unauthorized")]
     Unauthorized,
 

--- a/contracts/adapters/swap/osmosis-poolmanager/src/error.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/error.rs
@@ -15,6 +15,12 @@ pub enum ContractError {
     #[error(transparent)]
     Payment(#[from] cw_utils::PaymentError),
 
+    #[error(transparent)]
+    Decimal(#[from] cosmwasm_std::DecimalRangeExceeded),
+
+    #[error(transparent)]
+    Overflow(#[from] cosmwasm_std::OverflowError),
+
     #[error("Unauthorized")]
     Unauthorized,
 

--- a/contracts/adapters/swap/osmosis-poolmanager/src/error.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/error.rs
@@ -15,6 +15,9 @@ pub enum ContractError {
     #[error(transparent)]
     Payment(#[from] cw_utils::PaymentError),
 
+    #[error(transparent)]
+    Overflow(#[from] cosmwasm_std::OverflowError),
+
     #[error("Unauthorized")]
     Unauthorized,
 

--- a/deployed-contracts/neutron/mainnet.toml
+++ b/deployed-contracts/neutron/mainnet.toml
@@ -1,36 +1,28 @@
 [info]
 chain_id = "neutron-1"
 network = "mainnet"
-deploy_date = "14/11/2023 20:03:16"
-commit_hash = "232655636ec35c9ef89b3d1eba8e618e04bc0310"
-salt = "5"
+deploy_date = "29/11/2023 23:45:00"
+commit_hash = ""
+salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "f57d106ef282572b7659600627e0cce5f11bbb24a87fbe56eec53b38910b1520"
+"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "66ce6793d02cf24d4d04b7053f6e04d8b52ce7cd790d6abc19930c5ef6961602"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "fe2a2d2cac64f32a640278cd2d942090b88271f7ef134ce89f57e732253326d3"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3b6340dbb46ace9c8471b58f49f1d6de69cd4cd1b2b746a33ef955d16c29413b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
 
 [code-ids]
-ibc_transfer_adapter_contract_code_id = "473"
-swap_adapter_neutron-astroport_contract_code_id = "474"
-swap_adapter_neutron-lido-satellite_contract_code_id = "475"
-entry_point_contract_code_id = "476"
+swap_adapter_neutron-astroport_contract_code_id = "497"
+swap_adapter_neutron-lido-satellite_contract_code_id = "498"
 
 [contract-addresses]
-ibc_transfer_adapter_contract_address = "neutron1u3eaxthssyat58drzn0zw7xvd79g5wj80fuf9hj8hyutus25n9jqxfldmv"
-swap_adapter_neutron-astroport_contract_address = "neutron1am2g0khzkelml6r0z23zqpm2rwpnpqq0fgjs82levh44hcd74rksqnxfn9"
-swap_adapter_neutron-lido-satellite_contract_address = "neutron1t53gvsjlzmkry9t2k7nunz0v8dznzdymajwg4g0t4crx8qnfzc2qwzufcw"
-entry_point_contract_address = "neutron1f2eyuz7dm0ec5smg47wlu5rkcucd64gvveqglmu5tzwa09sslf8set9qnh"
+swap_adapter_neutron-astroport_contract_address = "neutron1kp7jeuc8hnfyxys6l260uasxpha47kvn4xdhl76y7hqwkf2sv40qch73cp"
+swap_adapter_neutron-lido-satellite_contract_address = "neutron1j09s2nxtsdff2vtdhfuqpq67nyp8cx075ate82tkmx9ycua7ezlspnda94"
 
 [tx-hashes]
-store_ibc_transfer_adapter_tx_hash = "881d6f48a7f2bf07650ca6bcf06dc5af30c7ee5419256ac4bd62682788eff31e"
-instantiate_ibc_transfer_adapter_tx_hash = "86c3537085a94d6f1803635ff2ccece6571a8157d8b99af5259b84e243bc2f40"
-store_swap_adapter_neutron-astroport_tx_hash = "187f5b930c0cadd6e63674dad87320d20709f6b521798fe2a4c0ae33ac093c3a"
-instantiate_swap_adapter_neutron-astroport_tx_hash = "2f19b8c7b55efffb62eca2fb944966e5086c77923d4d5316de724687808c5705"
-store_swap_adapter_neutron-lido-satellite_tx_hash = "fd96db52f8c8ae1fc75d16612267bea142fea40ecc27c3f58fc71aab1c3996c5"
-instantiate_swap_adapter_neutron-lido-satellite_tx_hash = "b7f069c7a82db415079c7a1e59cf0654f082a016b86e50e8ee0ede8706005e82"
-store_entry_point_tx_hash = "f40772a1e5f4a882cae8f869e4798e2c9a4815fe7530c8949e3f0080a04153eb"
-instantiate_entry_point_tx_hash = "3bbe45a45bd11defcc21dbb8451be5a0a8eed7425b9f956cbff10fd35bc78cca"
+store_swap_adapter_neutron-astroport_tx_hash = "3568d3f4c3dc005c658b24c3bdb104b6d18fbf722b9d8f59c672fa475da4b269"
+instantiate_swap_adapter_neutron-astroport_tx_hash = "85b69fddc2a58a14e76e9149eee9de99892dc7066368e13c9855b3fab619a44c"
+store_swap_adapter_neutron-lido-satellite_tx_hash = "44ddb8ffc087e84ac126c181b0eb42ac2bf707eda099050afcd00aeb576471db"
+instantiate_swap_adapter_neutron-lido-satellite_tx_hash = "7456d42ff1b6841d51bd0a9627067c438bc6e901521a9a900bef3a23caba4b39"

--- a/deployed-contracts/neutron/mainnet.toml
+++ b/deployed-contracts/neutron/mainnet.toml
@@ -1,28 +1,28 @@
 [info]
 chain_id = "neutron-1"
 network = "mainnet"
-deploy_date = "29/11/2023 23:45:00"
-commit_hash = ""
+deploy_date = "06/12/2023 00:12:29"
+commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "e56940041e5943ff4090047c7a5c3f4a0bc41687cc7a77fb5286b7f194caf438"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_neutron-astroport_contract_code_id = "497"
-swap_adapter_neutron-lido-satellite_contract_code_id = "498"
+swap_adapter_neutron-astroport_contract_code_id = "503"
+swap_adapter_neutron-lido-satellite_contract_code_id = "504"
 
 [contract-addresses]
-swap_adapter_neutron-astroport_contract_address = "neutron1kp7jeuc8hnfyxys6l260uasxpha47kvn4xdhl76y7hqwkf2sv40qch73cp"
-swap_adapter_neutron-lido-satellite_contract_address = "neutron1j09s2nxtsdff2vtdhfuqpq67nyp8cx075ate82tkmx9ycua7ezlspnda94"
+swap_adapter_neutron-astroport_contract_address = "neutron1rfecgx55wwnqmjtm9sq36xkph53xwfhah2uaslq8ghgg2qy66ads99d5cu"
+swap_adapter_neutron-lido-satellite_contract_address = "neutron16whscshfulc2cldxy0xprllvqqu7c4tet6u92qltdd6kjgn0phps67jt7k"
 
 [tx-hashes]
-store_swap_adapter_neutron-astroport_tx_hash = "3568d3f4c3dc005c658b24c3bdb104b6d18fbf722b9d8f59c672fa475da4b269"
-instantiate_swap_adapter_neutron-astroport_tx_hash = "85b69fddc2a58a14e76e9149eee9de99892dc7066368e13c9855b3fab619a44c"
-store_swap_adapter_neutron-lido-satellite_tx_hash = "44ddb8ffc087e84ac126c181b0eb42ac2bf707eda099050afcd00aeb576471db"
-instantiate_swap_adapter_neutron-lido-satellite_tx_hash = "7456d42ff1b6841d51bd0a9627067c438bc6e901521a9a900bef3a23caba4b39"
+store_swap_adapter_neutron-astroport_tx_hash = "10a106ecf5c130f3d567581f270a456448664a8e3dfbf60f87c802a76573910a"
+instantiate_swap_adapter_neutron-astroport_tx_hash = "ec9fa5c4fd4fd89d61d19923dd2ca76e82312b6f33ce852a9220a36e54298e8a"
+store_swap_adapter_neutron-lido-satellite_tx_hash = "584597221bbea030029be7c9712ae94fb5a52ec59ccb04c9f3a61b0d5e2375e2"
+instantiate_swap_adapter_neutron-lido-satellite_tx_hash = "fff3715a62ea49c74c2a00ad0fd24dc82da056fedaf45d5cb5bce444f54f7b29"

--- a/deployed-contracts/neutron/testnet.toml
+++ b/deployed-contracts/neutron/testnet.toml
@@ -1,36 +1,28 @@
 [info]
 chain_id = "pion-1"
 network = "testnet"
-deploy_date = "14/11/2023 19:56:26"
-commit_hash = "232655636ec35c9ef89b3d1eba8e618e04bc0310"
-salt = "5"
+deploy_date = "29/11/2023 23:42:09"
+commit_hash = ""
+salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "f57d106ef282572b7659600627e0cce5f11bbb24a87fbe56eec53b38910b1520"
+"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "66ce6793d02cf24d4d04b7053f6e04d8b52ce7cd790d6abc19930c5ef6961602"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "fe2a2d2cac64f32a640278cd2d942090b88271f7ef134ce89f57e732253326d3"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3b6340dbb46ace9c8471b58f49f1d6de69cd4cd1b2b746a33ef955d16c29413b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
 
 [code-ids]
-ibc_transfer_adapter_contract_code_id = "2031"
-swap_adapter_testnet-neutron-astroport_contract_code_id = "2032"
-swap_adapter_testnet-neutron-lido-satellite_contract_code_id = "2033"
-entry_point_contract_code_id = "2034"
+swap_adapter_testnet-neutron-astroport_contract_code_id = "2100"
+swap_adapter_testnet-neutron-lido-satellite_contract_code_id = "2101"
 
 [contract-addresses]
-ibc_transfer_adapter_contract_address = "neutron134xj3095m9jx8suqtemy8wq2w2qvqm7hhzskuzwdmtv0rrxjd63sj47afk"
-swap_adapter_testnet-neutron-astroport_contract_address = "neutron17etzrl7sa3vr72z5e0e5y9c54j8drknm4p8lhks0ju435skmy76s2t24q5"
-swap_adapter_testnet-neutron-lido-satellite_contract_address = "neutron12d6e3n0cje67lhyzs8t6m5c59zfzk28nthhgnyu6rrn7k4t84zlqcu3l6m"
-entry_point_contract_address = "neutron1f2eyuz7dm0ec5smg47wlu5rkcucd64gvveqglmu5tzwa09sslf8set9qnh"
+swap_adapter_testnet-neutron-astroport_contract_address = "neutron1df0qa7vg6avdn47ls6apke45kpvu3nyl27kxm62h3qnjsx0x0rcsvac686"
+swap_adapter_testnet-neutron-lido-satellite_contract_address = "neutron16nz79jnk8xlean647xw0zawr9tq22hk22lhdm73c384heauq39yst7hv2a"
 
 [tx-hashes]
-store_ibc_transfer_adapter_tx_hash = "c5fd156e0cbdbe26526385f19eef4212d9652b727066d994f956a1bbbf56578c"
-instantiate_ibc_transfer_adapter_tx_hash = "93fddae58a83293bf8a81118c1dedf851601e0516a825243789bcb879c6d567d"
-store_swap_adapter_testnet-neutron-astroport_tx_hash = "92e75ece80cc6ad567065e842cb3fb2feffacf7d8f16be881a8ef3fadeba3b44"
-instantiate_swap_adapter_testnet-neutron-astroport_tx_hash = "440e2a7e4e12a5a6df29644f92167ac4f6344b0614abbeab24178ecd100cb298"
-store_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "a368a8d30b7f23980b0b44629d51ebaa6d4fb7c950fa00f2a7a4a4bcf2345893"
-instantiate_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "2cbc8840424420dda9f8269ee698cf811a57288550df1b5dea65410521a108ec"
-store_entry_point_tx_hash = "2f4eae0b24cd111265b8807e9dddc89157b79506a6a6363df67ec754a0b53e53"
-instantiate_entry_point_tx_hash = "7698e350059100117c99c37c93340cb80ceb960d0ddae184fe43bc61ad2c208a"
+store_swap_adapter_testnet-neutron-astroport_tx_hash = "5713ea5fe14ae8703420f6de8812da44531b1d8aa95194655e89dcee3fd88d89"
+instantiate_swap_adapter_testnet-neutron-astroport_tx_hash = "7eaf64287876cb1097bb4cbe5f018781fb0c74b44a853c69182260f36817b4b6"
+store_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "3c31dea91bdce19044d2da220af65402397b21ec8aa4a195ea0edee8e04ad3d1"
+instantiate_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "07365d91cfd97e6227b405dbd589a559af6bd9bb07f579d17165fd2d6c63c1ca"

--- a/deployed-contracts/neutron/testnet.toml
+++ b/deployed-contracts/neutron/testnet.toml
@@ -1,28 +1,28 @@
 [info]
 chain_id = "pion-1"
 network = "testnet"
-deploy_date = "29/11/2023 23:42:09"
-commit_hash = ""
+deploy_date = "06/12/2023 00:04:49"
+commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "e56940041e5943ff4090047c7a5c3f4a0bc41687cc7a77fb5286b7f194caf438"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_testnet-neutron-astroport_contract_code_id = "2100"
-swap_adapter_testnet-neutron-lido-satellite_contract_code_id = "2101"
+swap_adapter_testnet-neutron-astroport_contract_code_id = "2174"
+swap_adapter_testnet-neutron-lido-satellite_contract_code_id = "2175"
 
 [contract-addresses]
-swap_adapter_testnet-neutron-astroport_contract_address = "neutron1df0qa7vg6avdn47ls6apke45kpvu3nyl27kxm62h3qnjsx0x0rcsvac686"
-swap_adapter_testnet-neutron-lido-satellite_contract_address = "neutron16nz79jnk8xlean647xw0zawr9tq22hk22lhdm73c384heauq39yst7hv2a"
+swap_adapter_testnet-neutron-astroport_contract_address = "neutron17cmwntfmsp40gt79s8f6sjuxzg4hg7sn3m6ehc76dwr3uz0xt45qn5gvvd"
+swap_adapter_testnet-neutron-lido-satellite_contract_address = "neutron19jgas6ugw53czhk6xd6tp542m0jtgux8tnfa5wwmyju0zz2rv5rsjza0uk"
 
 [tx-hashes]
-store_swap_adapter_testnet-neutron-astroport_tx_hash = "5713ea5fe14ae8703420f6de8812da44531b1d8aa95194655e89dcee3fd88d89"
-instantiate_swap_adapter_testnet-neutron-astroport_tx_hash = "7eaf64287876cb1097bb4cbe5f018781fb0c74b44a853c69182260f36817b4b6"
-store_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "3c31dea91bdce19044d2da220af65402397b21ec8aa4a195ea0edee8e04ad3d1"
-instantiate_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "07365d91cfd97e6227b405dbd589a559af6bd9bb07f579d17165fd2d6c63c1ca"
+store_swap_adapter_testnet-neutron-astroport_tx_hash = "416ac3dc84c4384b19940021b4b327f68175f960a45aa023611252669ecf02dd"
+instantiate_swap_adapter_testnet-neutron-astroport_tx_hash = "f1e3c1d2f326b527a7ebf6b3abe5b40affc2d52edabf3892fb9eb64a07cb6584"
+store_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "69afd92dccaba0d16d5d218e55e3b395bdde4cf57cb6d49efbce3d8c1adfa427"
+instantiate_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "953258eedf110cf8f4abb913826e43f4fd8a3a8541659d6efdc32ceac67d80a5"

--- a/deployed-contracts/osmosis/mainnet.toml
+++ b/deployed-contracts/osmosis/mainnet.toml
@@ -1,24 +1,24 @@
 [info]
 chain_id = "osmosis-1"
 network = "mainnet"
-deploy_date = "29/11/2023 23:56:07"
-commit_hash = ""
+deploy_date = "06/12/2023 01:53:21"
+commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "e56940041e5943ff4090047c7a5c3f4a0bc41687cc7a77fb5286b7f194caf438"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_osmosis-poolmanager_contract_code_id = "295"
+swap_adapter_osmosis-poolmanager_contract_code_id = "318"
 
 [contract-addresses]
-swap_adapter_osmosis-poolmanager_contract_address = "osmo1jp27khq7anyk9jdnnzt3yk4kcnactqvha2gzu00e0uy3qhn84fpqlg6pwc"
+swap_adapter_osmosis-poolmanager_contract_address = "osmo13tr3xj7vthy56phpcuc2w0kruy9xalgwurz4z9jy3q2m4wxl529sfwt9d0"
 
 [tx-hashes]
-store_swap_adapter_osmosis-poolmanager_tx_hash = "37fd455ed7136d47f6046f37cec974bbcf9d35a847505a0d0459c3717708cdc9"
-instantiate_swap_adapter_osmosis-poolmanager_tx_hash = "0aec9c7b3c2f54bd68459f5e1e22188740b5a473d6f3793b42958a0aca476f86"
+store_swap_adapter_osmosis-poolmanager_tx_hash = "c41d719113f9025bf4c953b92f61a234c69e543d77859eba7c5118113bbcb8ed"
+instantiate_swap_adapter_osmosis-poolmanager_tx_hash = "6d60594f58f79447bac37a641f96a271119c2e1b2a4c5240c6150006d5b0ffb3"

--- a/deployed-contracts/osmosis/mainnet.toml
+++ b/deployed-contracts/osmosis/mainnet.toml
@@ -1,30 +1,24 @@
 [info]
 chain_id = "osmosis-1"
 network = "mainnet"
-deploy_date = "08/11/2023 11:12:23"
-commit_hash = "845f8de176181a8282b0f5eed233457c726ee2b5"
+deploy_date = "29/11/2023 23:56:07"
+commit_hash = ""
+salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "d0b5cad15c127c5eff36096ea9d5bcec1703d0e22f906f40c3ee86be3fef3494"
-"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "50a8503dc625592079f2f9ad9bee92ea2a6dd1e86802a56083c578237a0806bd"
-"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "2d35fbab62f8632dc8e71aa748f14db06fea70af62f2795562d5e62057af843d"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "daf0a052475abf9ff25af32102ca0c93117d4680e2a5c0a2724200dfa301a05f"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "d9343ccf2b48a3e76ca1d6b8ac9c13dd0ee8447d84df866d727e982eecb5f26c"
+"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
+"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
 
 [code-ids]
-swap_adapter_contract_code_id = "266"
-ibc_transfer_adapter_contract_code_id = "267"
-entry_point_contract_code_id = "268"
+swap_adapter_osmosis-poolmanager_contract_code_id = "295"
 
 [contract-addresses]
-swap_adapter_contract_address = "osmo1nj7eddup433ax9rze3yc48a0k7gkjnlaftznpxpdvqumm30npjrqlnhxck"
-ibc_transfer_adapter_contract_address = "osmo1c8huw6w6p85kew98uv78g0nm3zue6jl8w78254r900kex9w72krsjjp2du"
-entry_point_contract_address = "osmo1ln7rurzjr4x5403qhpyuma0x53dgkzkk0vewf3xr7rc24s57yzvshuqzdv"
+swap_adapter_osmosis-poolmanager_contract_address = "osmo1jp27khq7anyk9jdnnzt3yk4kcnactqvha2gzu00e0uy3qhn84fpqlg6pwc"
 
 [tx-hashes]
-store_swap_adapter_tx_hash = "26e07b232b2998e8a065913aaa87d31a7d0f14b4c0e03886c0183ea2c1e97ec9"
-store_ibc_transfer_adapter_tx_hash = "d0011fd431d746d5e43f1ba00cb639adb7b3f83c893c1433ad34d8b7cc0575b2"
-store_entry_point_tx_hash = "c17217bec56817b0e964e450a9c086b8925dd6f0b8303cf0d50c5e84c8b652aa"
-instantiate_swap_adapter_tx_hash = "ef81c025d8dd532dc54dfc0f0428b6b46a1e9a601d8f62a5d329fdbb632d3278"
-instantiate_ibc_transfer_adapter_tx_hash = "49b68cff8415ad04b2506eba35852bdc13ed206427fb05d215a1332884f3ddbf"
-instantiate_entry_point_tx_hash = "d1790a7df3a194345783aba364722e158222c0dd4e8c74e07942fc6e2c965fc3"
+store_swap_adapter_osmosis-poolmanager_tx_hash = "37fd455ed7136d47f6046f37cec974bbcf9d35a847505a0d0459c3717708cdc9"
+instantiate_swap_adapter_osmosis-poolmanager_tx_hash = "0aec9c7b3c2f54bd68459f5e1e22188740b5a473d6f3793b42958a0aca476f86"

--- a/deployed-contracts/osmosis/testnet.toml
+++ b/deployed-contracts/osmosis/testnet.toml
@@ -1,30 +1,24 @@
 [info]
 chain_id = "osmo-test-5"
 network = "testnet"
-deploy_date = "08/11/2023 11:02:12"
-commit_hash = "845f8de176181a8282b0f5eed233457c726ee2b5"
+deploy_date = "29/11/2023 23:54:49"
+commit_hash = ""
+salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "d0b5cad15c127c5eff36096ea9d5bcec1703d0e22f906f40c3ee86be3fef3494"
-"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "50a8503dc625592079f2f9ad9bee92ea2a6dd1e86802a56083c578237a0806bd"
-"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "2d35fbab62f8632dc8e71aa748f14db06fea70af62f2795562d5e62057af843d"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "daf0a052475abf9ff25af32102ca0c93117d4680e2a5c0a2724200dfa301a05f"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "d9343ccf2b48a3e76ca1d6b8ac9c13dd0ee8447d84df866d727e982eecb5f26c"
+"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
+"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
 
 [code-ids]
-swap_adapter_contract_code_id = "5043"
-ibc_transfer_adapter_contract_code_id = "5044"
-entry_point_contract_code_id = "5045"
+swap_adapter_testnet-osmosis-poolmanager_contract_code_id = "5387"
 
 [contract-addresses]
-swap_adapter_contract_address = "osmo1pdtpfmqywnqze8g2lhk6swc7gmqmexmy4cgdc4azhklaxjs2gt4q03szfr"
-ibc_transfer_adapter_contract_address = "osmo10pwfvw9yhv972ze6v8e7n25uzyyckc58mftx8r0y3kdlnr08yrlss3ks75"
-entry_point_contract_address = "osmo1ln7rurzjr4x5403qhpyuma0x53dgkzkk0vewf3xr7rc24s57yzvshuqzdv"
+swap_adapter_testnet-osmosis-poolmanager_contract_address = "osmo10evkw6ugplwpprt9j0rvmdg40myvup8a0wwh3s3ay2q2pa6f2thqfqt405"
 
 [tx-hashes]
-store_swap_adapter_tx_hash = "9717977270239a5e0a3e8ff0b98082f1f329ebae3b2a418607400f0f768573da"
-store_ibc_transfer_adapter_tx_hash = "76b67c4bb247265872a8a7bfadb120ef34cd9136481c0e34cc4d1698359796d5"
-store_entry_point_tx_hash = "59776e5c0c9ce078b267f01207c1e5d95cb20628ab7e32c173f85cf168d8049f"
-instantiate_swap_adapter_tx_hash = "a40555238988ad4261ad99e08399a6562a378c4f46fa74647747aa470aab94f7"
-instantiate_ibc_transfer_adapter_tx_hash = "c62fe1e36901fecccba499cb2cda58e171fadee607d73689d66a979c9b0d38f7"
-instantiate_entry_point_tx_hash = "d6eb959880417cbd331fba654c7f3ad6e318ec7d81d409d45ccc9cb44c48537f"
+store_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "936926e3cf5a81977d89bb8ba5298bb98d44afa3fac0dcaaa4a7fe6677a232ca"
+instantiate_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "6bc746d51b83ba3dbaa26c8cd48c243a00acaf7439215bb3a410f12cf42ea76f"

--- a/deployed-contracts/osmosis/testnet.toml
+++ b/deployed-contracts/osmosis/testnet.toml
@@ -1,24 +1,24 @@
 [info]
 chain_id = "osmo-test-5"
 network = "testnet"
-deploy_date = "29/11/2023 23:54:49"
-commit_hash = ""
+deploy_date = "06/12/2023 01:47:50"
+commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "e56940041e5943ff4090047c7a5c3f4a0bc41687cc7a77fb5286b7f194caf438"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_testnet-osmosis-poolmanager_contract_code_id = "5387"
+swap_adapter_testnet-osmosis-poolmanager_contract_code_id = "5454"
 
 [contract-addresses]
-swap_adapter_testnet-osmosis-poolmanager_contract_address = "osmo10evkw6ugplwpprt9j0rvmdg40myvup8a0wwh3s3ay2q2pa6f2thqfqt405"
+swap_adapter_testnet-osmosis-poolmanager_contract_address = "osmo1q2rhzptx8f9jqvkfuf8e962sqaym5lhh6ep4l4uy5wa89gzttzxqundgdc"
 
 [tx-hashes]
-store_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "936926e3cf5a81977d89bb8ba5298bb98d44afa3fac0dcaaa4a7fe6677a232ca"
-instantiate_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "6bc746d51b83ba3dbaa26c8cd48c243a00acaf7439215bb3a410f12cf42ea76f"
+store_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "2780cdef30a23743f395eff959ceea724cdb8f8bec7761782f00231ca56a25e7"
+instantiate_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "5f2f9f4abfa6bb63bb78de8af3b58bb6703930e7e8c870b335e1b2aada59c17e"

--- a/deployed-contracts/terra/mainnet.toml
+++ b/deployed-contracts/terra/mainnet.toml
@@ -1,32 +1,24 @@
 [info]
 chain_id = "phoenix-1"
 network = "mainnet"
-deploy_date = "14/11/2023 18:05:20"
-commit_hash = "cc51e5c48b9cdfaeaab5f9f8e5bebdc69f139884"
-salt = "5"
+deploy_date = "29/11/2023 23:53:32"
+commit_hash = ""
+salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "d0b5cad15c127c5eff36096ea9d5bcec1703d0e22f906f40c3ee86be3fef3494"
-"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "50a8503dc625592079f2f9ad9bee92ea2a6dd1e86802a56083c578237a0806bd"
-"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "2d35fbab62f8632dc8e71aa748f14db06fea70af62f2795562d5e62057af843d"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "4556eb63bf22495550bdfece5becec45069e70b7029828c2983f03839adb421f"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "fe2a2d2cac64f32a640278cd2d942090b88271f7ef134ce89f57e732253326d3"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "d9343ccf2b48a3e76ca1d6b8ac9c13dd0ee8447d84df866d727e982eecb5f26c"
+"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
+"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
 
 [code-ids]
-swap_adapter_contract_code_id = "2117"
-ibc_transfer_adapter_contract_code_id = "2118"
-entry_point_contract_code_id = "2119"
+swap_adapter_terra-astroport_contract_code_id = "2263"
 
 [contract-addresses]
-swap_adapter_contract_address = "terra1kvpwff7r32udccky6nthculmwqkxacj55t6ewj8n4nfur4ya9zfqmytnyw"
-ibc_transfer_adapter_contract_address = "terra128tk9ywqn8yutsqyp3ja4v507r56tqa3tjqhggkt90kmgw8dhhhswsqff5"
-entry_point_contract_address = "terra1ht7d6h4320hr34tyshunrfclfyatlvsgxpezpgxzs4n37vx0f55qdjhtpg"
+swap_adapter_terra-astroport_contract_address = "terra1hy0fnxvp8rdzezzngnca72qzxv8sj38xxlvcs2uj0zf0re0z37jq0d6d7l"
 
 [tx-hashes]
-store_swap_adapter_tx_hash = "bdac412b458c817f88ee6dcfafd86d9338436ae5a87e7c9e2a90cb9892542a09"
-store_ibc_transfer_adapter_tx_hash = "79405e483184c2ea6f459b78ee3f4dad509458173cc743eeb3fda315c35e1b2a"
-store_entry_point_tx_hash = "c3d2a35f79b1c985109731ecbef5805a1dfa8b265ff51f803d3d189947b9963e"
-instantiate_swap_adapter_tx_hash = "6baee2c900d8ad293c89e66f95a9cef03dff18f3a94fc07345d0a30534dcbade"
-instantiate_ibc_transfer_adapter_tx_hash = "96caa9864a466c4d2ebcdf497607b5ec230346b38e85ab17c522f0c51caa2c40"
-instantiate_entry_point_tx_hash = "50dcd1970f168e69c92baa063aaee9fb8be78c702ae76861717520ec9878bfe1"
+store_swap_adapter_terra-astroport_tx_hash = "639f63629e350e6a25fdfcd6f714c19cf05a66364557df7b8173f7330d9cbdea"
+instantiate_swap_adapter_terra-astroport_tx_hash = "a493e909ab24b41a04de057628d365c2de234e5b9a777de6fb1ca7ad106bea48"

--- a/deployed-contracts/terra/mainnet.toml
+++ b/deployed-contracts/terra/mainnet.toml
@@ -1,24 +1,24 @@
 [info]
 chain_id = "phoenix-1"
 network = "mainnet"
-deploy_date = "29/11/2023 23:53:32"
-commit_hash = ""
+deploy_date = "06/12/2023 00:45:22"
+commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "e56940041e5943ff4090047c7a5c3f4a0bc41687cc7a77fb5286b7f194caf438"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_terra-astroport_contract_code_id = "2263"
+swap_adapter_terra-astroport_contract_code_id = "2294"
 
 [contract-addresses]
-swap_adapter_terra-astroport_contract_address = "terra1hy0fnxvp8rdzezzngnca72qzxv8sj38xxlvcs2uj0zf0re0z37jq0d6d7l"
+swap_adapter_terra-astroport_contract_address = "terra17wf3v0slvh7anc68f3rmz3s3u5x56qhw9yyul94vpcdwmp89fcqqylmvth"
 
 [tx-hashes]
-store_swap_adapter_terra-astroport_tx_hash = "639f63629e350e6a25fdfcd6f714c19cf05a66364557df7b8173f7330d9cbdea"
-instantiate_swap_adapter_terra-astroport_tx_hash = "a493e909ab24b41a04de057628d365c2de234e5b9a777de6fb1ca7ad106bea48"
+store_swap_adapter_terra-astroport_tx_hash = "899cc5d6c0b789ead09a17ed554dc27b4fbdf5674d6d5e94373493335985c7fb"
+instantiate_swap_adapter_terra-astroport_tx_hash = "fcf94af30d3227d5dab8b323e568355d76b23b5fd7d152aae2fc0f15cf8dc20c"

--- a/deployed-contracts/terra/testnet.toml
+++ b/deployed-contracts/terra/testnet.toml
@@ -1,32 +1,24 @@
 [info]
 chain_id = "pisco-1"
 network = "testnet"
-deploy_date = "14/11/2023 17:57:05"
-commit_hash = "cc51e5c48b9cdfaeaab5f9f8e5bebdc69f139884"
-salt = "5"
+deploy_date = "29/11/2023 23:50:39"
+commit_hash = ""
+salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "d0b5cad15c127c5eff36096ea9d5bcec1703d0e22f906f40c3ee86be3fef3494"
-"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "50a8503dc625592079f2f9ad9bee92ea2a6dd1e86802a56083c578237a0806bd"
-"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "2d35fbab62f8632dc8e71aa748f14db06fea70af62f2795562d5e62057af843d"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "4556eb63bf22495550bdfece5becec45069e70b7029828c2983f03839adb421f"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "fe2a2d2cac64f32a640278cd2d942090b88271f7ef134ce89f57e732253326d3"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "d9343ccf2b48a3e76ca1d6b8ac9c13dd0ee8447d84df866d727e982eecb5f26c"
+"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
+"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
 
 [code-ids]
-swap_adapter_contract_code_id = "11811"
-ibc_transfer_adapter_contract_code_id = "11812"
-entry_point_contract_code_id = "11813"
+swap_adapter_testnet-terra-astroport_contract_code_id = "12143"
 
 [contract-addresses]
-swap_adapter_contract_address = "terra1dzlxull0aejxzfq68znckfe8dwn78enp5uc4txm42zwcz28a78lqfdypmc"
-ibc_transfer_adapter_contract_address = "terra1pg0l4arfc3e658ckmn34zfxte9qt84xmv2nz0ypypnycnp54rsfsws3z3g"
-entry_point_contract_address = "terra1ht7d6h4320hr34tyshunrfclfyatlvsgxpezpgxzs4n37vx0f55qdjhtpg"
+swap_adapter_testnet-terra-astroport_contract_address = "terra14ag8k2lpxv74jqlkk0dtcnvcvjj6keycrv2ak8ukdwey445l87fsrxwkqy"
 
 [tx-hashes]
-store_swap_adapter_tx_hash = "beab112ff99d0916a8de41c65510e6535fbe218202fd74c78fefa5068e628115"
-store_ibc_transfer_adapter_tx_hash = "f99b61f278e193c4fcf137ba43784891c8a970193daa82a22a1ca9422601a030"
-store_entry_point_tx_hash = "b4b37ffd5233e2562f242f5fa7811650240b9ad6647c02e0323624472fd4e497"
-instantiate_swap_adapter_tx_hash = "95f8909490d7c70b72aabfa6e169ddb5f38ea0e5920baa9a9be23d9d3bfe24fb"
-instantiate_ibc_transfer_adapter_tx_hash = "f1c03632695dcf5c61324001c68ffea6565da1aca31c0274958cf17dc6124d75"
-instantiate_entry_point_tx_hash = "16efb4490d5ae5f0a01c423625556eae507f365e67c350b81b5bb2070651b415"
+store_swap_adapter_testnet-terra-astroport_tx_hash = "e288d4a1fa61d69ee519b5326b295c2fbc2307bc47285972ceeb400d476feb1b"
+instantiate_swap_adapter_testnet-terra-astroport_tx_hash = "f11fed621231009d6e1e8c2476bde75c6cdbaba559f1f04af1097660150eb594"

--- a/deployed-contracts/terra/testnet.toml
+++ b/deployed-contracts/terra/testnet.toml
@@ -1,24 +1,24 @@
 [info]
 chain_id = "pisco-1"
 network = "testnet"
-deploy_date = "29/11/2023 23:50:39"
-commit_hash = ""
+deploy_date = "06/12/2023 00:43:22"
+commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "78aedc54514702fdd4c7385cfacf43ff8ba0ba6406053f89b37f247d52816aab"
+"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
-"skip_api_swap_adapter_astroport-aarch64.wasm" = "1271398f1f1a9da56d245f737a9cf154e8c7862e94cdc1eae83e14d74cc40e61"
-"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "7ddba8dd382112df5f87cbf0d65d19f3713e74e70a4bb57abda0233c1e020ab7"
-"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "3239e27f19e8d427bab5738a0fd5b1ae31836d8900c1d4d37fe1340e6aa6e14b"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "e56940041e5943ff4090047c7a5c3f4a0bc41687cc7a77fb5286b7f194caf438"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_testnet-terra-astroport_contract_code_id = "12143"
+swap_adapter_testnet-terra-astroport_contract_code_id = "12185"
 
 [contract-addresses]
-swap_adapter_testnet-terra-astroport_contract_address = "terra14ag8k2lpxv74jqlkk0dtcnvcvjj6keycrv2ak8ukdwey445l87fsrxwkqy"
+swap_adapter_testnet-terra-astroport_contract_address = "terra1hn224pg9pepe62d4dlnq9u7jw6s3qdanf4dmujswxsh27l7hz3hq357ue9"
 
 [tx-hashes]
-store_swap_adapter_testnet-terra-astroport_tx_hash = "e288d4a1fa61d69ee519b5326b295c2fbc2307bc47285972ceeb400d476feb1b"
-instantiate_swap_adapter_testnet-terra-astroport_tx_hash = "f11fed621231009d6e1e8c2476bde75c6cdbaba559f1f04af1097660150eb594"
+store_swap_adapter_testnet-terra-astroport_tx_hash = "a5d2643c7688448a3851d953dfc3315cb972544149f28f2fa708d87ac1179b53"
+instantiate_swap_adapter_testnet-terra-astroport_tx_hash = "ede1cc1a42ab7d7eb38065a325e954d410af43267c5091352f114fb0611ebb4d"

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -4,7 +4,7 @@ use std::{convert::TryFrom, num::ParseIntError};
 
 use astroport::{asset::AssetInfo, router::SwapOperation as AstroportSwapOperation};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Api, BankMsg, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{Addr, Api, BankMsg, CosmosMsg, DepsMut, Env, MessageInfo, Response};
 use cw20::Cw20Contract;
 use cw20::Cw20ReceiveMsg;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
@@ -67,33 +67,17 @@ pub enum QueryMsg {
     #[returns(Addr)]
     RouterContractAddress {},
     // SimulateSwapExactAssetOut returns the asset in necessary to receive the specified asset out
-    #[returns(SimulateSwapExactAssetOutResponse)]
+    #[returns(Asset)]
     SimulateSwapExactAssetOut {
         asset_out: Asset,
         swap_operations: Vec<SwapOperation>,
     },
     // SimulateSwapExactAssetIn returns the asset out received from the specified asset in
-    #[returns(SimulateSwapExactAssetInResponse)]
+    #[returns(Asset)]
     SimulateSwapExactAssetIn {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
     },
-}
-
-// The SimulateSwapExactAssetInResponse struct defines the response for the
-// SimulateSwapExactAssetIn query.
-#[cw_serde]
-pub struct SimulateSwapExactAssetInResponse {
-    pub asset_out: Asset,
-    pub spot_price: Decimal,
-}
-
-// The SimulateSwapExactAssetOutResponse struct defines the response for the
-// SimulateSwapExactAssetOut query.
-#[cw_serde]
-pub struct SimulateSwapExactAssetOutResponse {
-    pub asset_in: Asset,
-    pub spot_price: Decimal,
 }
 
 ////////////////////

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -78,15 +78,15 @@ pub enum QueryMsg {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
     },
-    // SimulateSwapExactAssetOutWithSpotPrice returns the asset in necessary to receive the specified asset out and the spot price
+    // SimulateSwapExactAssetOutWithSpotPrice returns the asset in necessary to receive the specified asset out with metadata
     #[returns(SimulateSwapExactAssetOutResponse)]
-    SimulateSwapExactAssetOutWithSpotPrice {
+    SimulateSwapExactAssetOutWithMetadata {
         asset_out: Asset,
         swap_operations: Vec<SwapOperation>,
     },
-    // SimulateSwapExactAssetInWithSpotPrice returns the asset out received from the specified asset in and the spot price
+    // SimulateSwapExactAssetInWithSpotPrice returns the asset out received from the specified asset in with metadata
     #[returns(SimulateSwapExactAssetInResponse)]
-    SimulateSwapExactAssetInWithSpotPrice {
+    SimulateSwapExactAssetInWithMetadata {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
     },
@@ -97,7 +97,7 @@ pub enum QueryMsg {
 #[cw_serde]
 pub struct SimulateSwapExactAssetInResponse {
     pub asset_out: Asset,
-    pub spot_price: Decimal,
+    pub spot_price: Option<Decimal>,
 }
 
 // The SimulateSwapExactAssetOutResponse struct defines the response for the
@@ -105,7 +105,7 @@ pub struct SimulateSwapExactAssetInResponse {
 #[cw_serde]
 pub struct SimulateSwapExactAssetOutResponse {
     pub asset_in: Asset,
-    pub spot_price: Decimal,
+    pub spot_price: Option<Decimal>,
 }
 
 ////////////////////

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -67,14 +67,26 @@ pub enum QueryMsg {
     #[returns(Addr)]
     RouterContractAddress {},
     // SimulateSwapExactAssetOut returns the asset in necessary to receive the specified asset out
-    #[returns(SimulateSwapExactAssetOutResponse)]
+    #[returns(Asset)]
     SimulateSwapExactAssetOut {
         asset_out: Asset,
         swap_operations: Vec<SwapOperation>,
     },
     // SimulateSwapExactAssetIn returns the asset out received from the specified asset in
-    #[returns(SimulateSwapExactAssetInResponse)]
+    #[returns(Asset)]
     SimulateSwapExactAssetIn {
+        asset_in: Asset,
+        swap_operations: Vec<SwapOperation>,
+    },
+    // SimulateSwapExactAssetOut returns the asset in necessary to receive the specified asset out
+    #[returns(SimulateSwapExactAssetOutResponse)]
+    SimulateSwapExactAssetOutWithSpotPrice {
+        asset_out: Asset,
+        swap_operations: Vec<SwapOperation>,
+    },
+    // SimulateSwapExactAssetIn returns the asset out received from the specified asset in
+    #[returns(SimulateSwapExactAssetInResponse)]
+    SimulateSwapExactAssetInWithSpotPrice {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
     },

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -83,12 +83,14 @@ pub enum QueryMsg {
     SimulateSwapExactAssetOutWithMetadata {
         asset_out: Asset,
         swap_operations: Vec<SwapOperation>,
+        include_spot_price: bool,
     },
     // SimulateSwapExactAssetInWithSpotPrice returns the asset out received from the specified asset in with metadata
     #[returns(SimulateSwapExactAssetInResponse)]
     SimulateSwapExactAssetInWithMetadata {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
+        include_spot_price: bool,
     },
 }
 

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -4,7 +4,7 @@ use std::{convert::TryFrom, num::ParseIntError};
 
 use astroport::{asset::AssetInfo, router::SwapOperation as AstroportSwapOperation};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::{Addr, Api, BankMsg, CosmosMsg, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{Addr, Api, BankMsg, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response};
 use cw20::Cw20Contract;
 use cw20::Cw20ReceiveMsg;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
@@ -67,17 +67,33 @@ pub enum QueryMsg {
     #[returns(Addr)]
     RouterContractAddress {},
     // SimulateSwapExactAssetOut returns the asset in necessary to receive the specified asset out
-    #[returns(Asset)]
+    #[returns(SimulateSwapExactAssetOutResponse)]
     SimulateSwapExactAssetOut {
         asset_out: Asset,
         swap_operations: Vec<SwapOperation>,
     },
     // SimulateSwapExactAssetIn returns the asset out received from the specified asset in
-    #[returns(Asset)]
+    #[returns(SimulateSwapExactAssetInResponse)]
     SimulateSwapExactAssetIn {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
     },
+}
+
+// The SimulateSwapExactAssetInResponse struct defines the response for the
+// SimulateSwapExactAssetIn query.
+#[cw_serde]
+pub struct SimulateSwapExactAssetInResponse {
+    pub asset_out: Asset,
+    pub spot_price: Decimal,
+}
+
+// The SimulateSwapExactAssetOutResponse struct defines the response for the
+// SimulateSwapExactAssetOut query.
+#[cw_serde]
+pub struct SimulateSwapExactAssetOutResponse {
+    pub asset_in: Asset,
+    pub spot_price: Decimal,
 }
 
 ////////////////////

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -78,13 +78,13 @@ pub enum QueryMsg {
         asset_in: Asset,
         swap_operations: Vec<SwapOperation>,
     },
-    // SimulateSwapExactAssetOut returns the asset in necessary to receive the specified asset out
+    // SimulateSwapExactAssetOutWithSpotPrice returns the asset in necessary to receive the specified asset out and the spot price
     #[returns(SimulateSwapExactAssetOutResponse)]
     SimulateSwapExactAssetOutWithSpotPrice {
         asset_out: Asset,
         swap_operations: Vec<SwapOperation>,
     },
-    // SimulateSwapExactAssetIn returns the asset out received from the specified asset in
+    // SimulateSwapExactAssetInWithSpotPrice returns the asset out received from the specified asset in and the spot price
     #[returns(SimulateSwapExactAssetInResponse)]
     SimulateSwapExactAssetInWithSpotPrice {
         asset_in: Asset,

--- a/scripts/configs/neutron.toml
+++ b/scripts/configs/neutron.toml
@@ -14,7 +14,7 @@ TESTNET_CHAIN_ID = "pion-1"
 
 ADDRESS_PREFIX = "neutron"
 DENOM = "untrn"
-GAS_PRICE = 0.01
+GAS_PRICE = 0.02
 
 # Contract Paths
 ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_api_entry_point-aarch64.wasm"

--- a/scripts/configs/osmosis.toml
+++ b/scripts/configs/osmosis.toml
@@ -4,12 +4,12 @@ MNEMONIC = "<YOUR MNEMONIC HERE>"
 # Commut Hash
 COMMIT_HASH = "<COMMIT HASH HERE>"
 
-MAINNET_REST_URL = "https://lcd.osmosis.zone/"
+MAINNET_REST_URL = "https://osmosis-api.polkachu.com"
 MAINNET_RPC_URL = "https://osmosis-rpc.polkachu.com/"
 MAINNET_CHAIN_ID = "osmosis-1"
 
-TESTNET_REST_URL = "https://lcd.osmotest5.osmosis.zone/"
-TESTNET_RPC_URL = "https://rpc.testnet.osmosis.zone/"
+TESTNET_REST_URL = "https://osmosis-testnet-api.polkachu.com"
+TESTNET_RPC_URL = "https://osmosis-testnet-rpc.polkachu.com/"
 TESTNET_CHAIN_ID = "osmo-test-5" 
 
 ADDRESS_PREFIX = "osmo"

--- a/scripts/configs/terra.toml
+++ b/scripts/configs/terra.toml
@@ -8,7 +8,7 @@ MAINNET_REST_URL = "https://phoenix-lcd.terra.dev"
 MAINNET_RPC_URL = "https://terra-rpc.polkachu.com/"
 MAINNET_CHAIN_ID = "phoenix-1"
 
-TESTNET_REST_URL = "https://terra-testnet-api.polkachu.com"
+TESTNET_REST_URL = "https://pisco-lcd.terra.dev"
 TESTNET_RPC_URL = "https://terra-testnet-rpc.polkachu.com/"
 TESTNET_CHAIN_ID = "pisco-1"
 


### PR DESCRIPTION
## Background
- We want to be able to return price impact back to api callers.

## This PR
- Creates two new query endpoints for swap venue adapter contracts that return a spot price in addition to the respective asset in/out depending on the simulation request. This is implemented as separate endpoints to not increase gas costs to core contract functionality.
- Updates deployed contracts to be of the latest deployment of swap venue contracts that expose the endpoints.