### PR TITLE
[API-2262] Make Sent Asset Param Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ make fmt
 
 # Deployment
 
-To deploy the Skip Swap contracts, the steps are as follows:
+To deploy the Skip Swap contracts, the steps are as follows: 
 
 1. Build the optimized wasm bytecode of the contracts by running (they will appear in an artifacts folder):
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The on-chain components of the swapping functionality consist of:
 
 ## Entry Point Contract
 
-The entry point contract is responsible for providing a standardized interface (w/ safety checks) to interact with Skip Swap across all CosmWasm-enabled chains. The contract:
+The entry point contract is responsible for providing a standardized interface (w/ safety checks) to interact with Skip Swap across all CosmWasm-enabled chains. The contract: 
 1. Performs basic validation on the call data.
 2. If a fee swap is provided, queries the swap adapter contract to determine how much of the coin sent with the contract call is needed to receive the required fee coin(s), and dispatches the swap.
 3. Dispatches the user swap provided in the call data to the relevant swap adapter contract.

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
     ``` toml
     # Enter your mnemonic here
-    MNEMONIC = "<YOUR MNEMONIC HERE>"
+    MNEMONIC = "<YOUR MNEMONIC HERE>" 
     ```
 
 7. Generate the entry point contract address using `instatiate2` which generates determinsitic cosmwasm contract addresses. This is necessary to allow the adapter contracts to whitelist the entry point contract before it is instantiated. To do this, you will need the daemon of the respective chain you are deploying on, and running the following command for the chain's CLI (replace osmosisd with network client being used):

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip
+# About Skip 
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts 
+# Skip API Contracts  
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ IBC Transfer adapter contracts are developed and deployed for each chain support
 
 A simplified example flow showcasing the interactions between the contracts is as follows:
 1. A user calls `swap_and_action` on the entry point contract.
-2. The entry point contract performs pre-swap validation checks on the user call.
+2. The entry point contract performs pre-swap validation checks on the user call. 
 3. The entry point contract calls `swap` on the relevant swap adapter contract, sending the coin to swap to the swap adapter contract.
 4. The swap adapter contract swaps the coin sent by the entry point contract to the desired output denom through the relevant swap venue.
 5. The swap adapter contract calls `transfer_funds_back` on itself, which transfers the post-swap contract balance back to the entry point contract.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip     
+# About Skip      
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip  
+# About Skip   
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts     
+# Skip API Contracts      
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The entry point contract is responsible for providing a standardized interface (
 1. Performs basic validation on the call data.
 2. If a fee swap is provided, queries the swap adapter contract to determine how much of the coin sent with the contract call is needed to receive the required fee coin(s), and dispatches the swap.
 3. Dispatches the user swap provided in the call data to the relevant swap adapter contract.
-4. Verifies the amount out received from the swap(s) is greater than the minimum amount required by the caller after all fees have been subtracted (swap, ibc, affiliate). 
+4. Verifies the amount out received from the swap(s) is greater than the minimum amount required by the caller after all fees have been subtracted (swap, ibc, affiliate).  
 5. Dispatches one of the following post-swap actions with the received funds from the swap:
     - Transfer to an address on the same chain.
     - IBC transfer to an address on a different chain (which allows for multi-hop IBC transfers or contract calls if the destination chains support it).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts       
+# Skip API Contracts        
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip         
+# About Skip
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts
+# Skip API Contracts 
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts    
+# Skip API Contracts     
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts        
+# Skip API Contracts         
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 9. Update the salt used in the config if needed (default is "1", which is 31 in the chain daemon generator)
     ``` toml
-    # SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+    # SALT USED TO GENERATE A DETERMINSTIC ADDRESS 
     SALT = "1"
     ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The entry point contract is responsible for providing a standardized interface (
 1. Performs basic validation on the call data.
 2. If a fee swap is provided, queries the swap adapter contract to determine how much of the coin sent with the contract call is needed to receive the required fee coin(s), and dispatches the swap.
 3. Dispatches the user swap provided in the call data to the relevant swap adapter contract.
-4. Verifies the amount out received from the swap(s) is greater than the minimum amount required by the caller after all fees have been subtracted (swap, ibc, affiliate).
+4. Verifies the amount out received from the swap(s) is greater than the minimum amount required by the caller after all fees have been subtracted (swap, ibc, affiliate). 
 5. Dispatches one of the following post-swap actions with the received funds from the swap:
     - Transfer to an address on the same chain.
     - IBC transfer to an address on a different chain (which allows for multi-hop IBC transfers or contract calls if the destination chains support it).

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ A simplified example flow showcasing the interactions between the contracts is a
 The repository is organized in the following way:
 ```
 │
-├── contracts/              <- Contains all contracts
+├── contracts/              <- Contains all contracts 
 │   ├── entry-point/        <- Contains source code and tests for entry point contract
 │   └── adapters/           <- Contains source code and tests for all network adapter contracts
 │       ├── ibc/

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip   
+# About Skip    
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip       
+# About Skip        
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts  
+# Skip API Contracts   
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts         
+# Skip API Contracts
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip 
+# About Skip  
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The entry point contract is responsible for providing a standardized interface (
 Swap Adapter contracts are developed and deployed for each swap venue supported by Skip Swap. The contracts are responsible for:
 1. Taking the standardized entry point swap operations message format and converting it to the specific swap venue's format.
 2. Swapping by calling the swap venue's respective smart contract or module.
-3. Providing query methods that can be called by the entry point contract (generally, to any external actor) to simulate multi-hop swaps that either specify an exact amount in (estimating how much would be received from the swap) or an exact amount out (estimating how much is required to get the specified amount out).
+3. Providing query methods that can be called by the entry point contract (generally, to any external actor) to simulate multi-hop swaps that either specify an exact amount in (estimating how much would be received from the swap) or an exact amount out (estimating how much is required to get the specified amount out). 
 
 ## IBC Transfer Adapter Contracts
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts      
+# Skip API Contracts       
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Skip Swap Swirl](assets/skip_swirl.png "Skipping, Swapping, and Swirling")
 
-# Skip API Contracts   
+# Skip API Contracts    
 
 The contracts in this repository are used in [Skip API](https://api-swagger.skip.money/) to enable any-to-any swaps as part of multi-chain workflows.
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The on-chain components of the swapping functionality consist of:
 
 ## Entry Point Contract
 
-The entry point contract is responsible for providing a standardized interface (w/ safety checks) to interact with Skip Swap across all CosmWasm-enabled chains. The contract: 
+The entry point contract is responsible for providing a standardized interface (w/ safety checks) to interact with Skip Swap across all CosmWasm-enabled chains. The contract:
 1. Performs basic validation on the call data.
 2. If a fee swap is provided, queries the swap adapter contract to determine how much of the coin sent with the contract call is needed to receive the required fee coin(s), and dispatches the swap.
 3. Dispatches the user swap provided in the call data to the relevant swap adapter contract.
-4. Verifies the amount out received from the swap(s) is greater than the minimum amount required by the caller after all fees have been subtracted (swap, ibc, affiliate).  
+4. Verifies the amount out received from the swap(s) is greater than the minimum amount required by the caller after all fees have been subtracted (swap, ibc, affiliate).
 5. Dispatches one of the following post-swap actions with the received funds from the swap:
     - Transfer to an address on the same chain.
     - IBC transfer to an address on a different chain (which allows for multi-hop IBC transfers or contract calls if the destination chains support it).
@@ -32,7 +32,7 @@ The entry point contract is responsible for providing a standardized interface (
 Swap Adapter contracts are developed and deployed for each swap venue supported by Skip Swap. The contracts are responsible for:
 1. Taking the standardized entry point swap operations message format and converting it to the specific swap venue's format.
 2. Swapping by calling the swap venue's respective smart contract or module.
-3. Providing query methods that can be called by the entry point contract (generally, to any external actor) to simulate multi-hop swaps that either specify an exact amount in (estimating how much would be received from the swap) or an exact amount out (estimating how much is required to get the specified amount out). 
+3. Providing query methods that can be called by the entry point contract (generally, to any external actor) to simulate multi-hop swaps that either specify an exact amount in (estimating how much would be received from the swap) or an exact amount out (estimating how much is required to get the specified amount out).
 
 ## IBC Transfer Adapter Contracts
 
@@ -47,7 +47,7 @@ IBC Transfer adapter contracts are developed and deployed for each chain support
 
 A simplified example flow showcasing the interactions between the contracts is as follows:
 1. A user calls `swap_and_action` on the entry point contract.
-2. The entry point contract performs pre-swap validation checks on the user call. 
+2. The entry point contract performs pre-swap validation checks on the user call.
 3. The entry point contract calls `swap` on the relevant swap adapter contract, sending the coin to swap to the swap adapter contract.
 4. The swap adapter contract swaps the coin sent by the entry point contract to the desired output denom through the relevant swap venue.
 5. The swap adapter contract calls `transfer_funds_back` on itself, which transfers the post-swap contract balance back to the entry point contract.
@@ -61,14 +61,14 @@ A simplified example flow showcasing the interactions between the contracts is a
 The repository is organized in the following way:
 ```
 │
-├── contracts/              <- Contains all contracts 
+├── contracts/              <- Contains all contracts
 │   ├── entry-point/        <- Contains source code and tests for entry point contract
 │   └── adapters/           <- Contains source code and tests for all network adapter contracts
 │       ├── ibc/
 │       │   ├── ibc-hooks/
 │       │   └── neutron-transfer/
 │       └── swap/
-│           ├── astroport/ 
+│           ├── astroport/
 │           └── osmosis-poolmanager/
 │
 ├── deployed-contracts/     <- Contains deployed contracts info for each network
@@ -124,7 +124,7 @@ make fmt
 
 # Deployment
 
-To deploy the Skip Swap contracts, the steps are as follows: 
+To deploy the Skip Swap contracts, the steps are as follows:
 
 1. Build the optimized wasm bytecode of the contracts by running (they will appear in an artifacts folder):
 
@@ -150,14 +150,14 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 5. Install all the dependencies:
     ```
-    pip install -r requirements.txt 
+    pip install -r requirements.txt
     ```
 
 6. Add the mnemonic of the deployer address in the respsective chain's config toml file (located in configs folder):
 
     ``` toml
     # Enter your mnemonic here
-    MNEMONIC = "<YOUR MNEMONIC HERE>" 
+    MNEMONIC = "<YOUR MNEMONIC HERE>"
     ```
 
 7. Generate the entry point contract address using `instatiate2` which generates determinsitic cosmwasm contract addresses. This is necessary to allow the adapter contracts to whitelist the entry point contract before it is instantiated. To do this, you will need the daemon of the respective chain you are deploying on, and running the following command for the chain's CLI (replace osmosisd with network client being used):
@@ -173,7 +173,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 9. Update the salt used in the config if needed (default is "1", which is 31 in the chain daemon generator)
     ``` toml
-    # SALT USED TO GENERATE A DETERMINSTIC ADDRESS 
+    # SALT USED TO GENERATE A DETERMINSTIC ADDRESS
     SALT = "1"
     ```
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 5. Install all the dependencies:
     ```
-    pip install -r requirements.txt
+    pip install -r requirements.txt 
     ```
 
 6. Add the mnemonic of the deployer address in the respsective chain's config toml file (located in configs folder):

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip    
+# About Skip     
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The repository is organized in the following way:
 │       │   ├── ibc-hooks/
 │       │   └── neutron-transfer/
 │       └── swap/
-│           ├── astroport/
+│           ├── astroport/ 
 │           └── osmosis-poolmanager/
 │
 ├── deployed-contracts/     <- Contains deployed contracts info for each network

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip      
+# About Skip       
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/README.md
+++ b/README.md
@@ -189,6 +189,6 @@ To deploy the Skip Swap contracts, the steps are as follows:
 
 11. After running the deploy script, a toml file will be added/updated in the deployed-contracts/{CHAIN} folder with all relevant info for the deployment.
 
-# About Skip        
+# About Skip         
 
 Skip helps developers provide extraordinary user experiences across all stages of the transaction lifecycle, from transaction construction, through cross-chain relaying + tracking, to block construction.

--- a/contracts/entry-point/tests/test_execute_receive.rs
+++ b/contracts/entry-point/tests/test_execute_receive.rs
@@ -142,7 +142,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "entry_point".to_string(), 
                     msg: to_binary(&ExecuteMsg::SwapAndAction {
-                        sent_asset: Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)}),
+                        sent_asset: Some(Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)})),
                         user_swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -73,7 +73,7 @@ Expect Error
 // Define test parameters
 struct Params {
     info_funds: Vec<Coin>,
-    sent_asset: Asset,
+    sent_asset: Option<Asset>,
     user_swap: Swap,
     min_asset: Asset,
     timeout_timestamp: u64,
@@ -89,7 +89,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -163,7 +163,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -239,7 +239,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -347,7 +347,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -437,7 +437,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -586,10 +586,10 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![],
-        sent_asset: Asset::Cw20(Cw20Coin {
+        sent_asset: Some(Asset::Cw20(Cw20Coin {
             address: "neutron123".to_string(),
             amount: Uint128::from(1_000_000u128),
-        }),
+        })),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -664,10 +664,10 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![],
-        sent_asset: Asset::Cw20(Cw20Coin {
+        sent_asset: Some(Asset::Cw20(Cw20Coin {
             address: "neutron123".to_string(),
             amount: Uint128::from(1_000_000u128),
-        }),
+        })),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -825,7 +825,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -908,7 +908,7 @@ struct Params {
         info_funds: vec![
             Coin::new(100_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(100_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(100_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -964,7 +964,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "uatom"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "uatom")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "uatom"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1016,7 +1016,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1068,7 +1068,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1120,7 +1120,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1160,7 +1160,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1208,7 +1208,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1260,7 +1260,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1312,7 +1312,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1362,7 +1362,7 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1391,7 +1391,7 @@ struct Params {
             Coin::new(1_000_000, "untrn"),
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1417,10 +1417,10 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![],
-        sent_asset: Asset::Cw20(Cw20Coin {
+        sent_asset: Some(Asset::Cw20(Cw20Coin {
             address: "neutron123".to_string(),
             amount: Uint128::from(2_000_000u128),
-        }),
+        })),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1446,10 +1446,10 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![Coin::new(1_000_000, "osmo")],
-        sent_asset: Asset::Cw20(Cw20Coin {
+        sent_asset: Some(Asset::Cw20(Cw20Coin {
             address: "neutron123".to_string(),
             amount: Uint128::from(1_000_000u128),
-        }),
+        })),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1477,7 +1477,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "osmo"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "osmo"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
@@ -1523,7 +1523,7 @@ struct Params {
         info_funds: vec![
             Coin::new(1_000_000, "untrn"),
         ],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -35,7 +35,7 @@ Expect Response
         - User Swap Exact Coin In With IBC Transfer With IBC Fees
         - User Swap Exact Coin In With IBC Transfer Without IBC Fees
         - Fee Swap And User Swap Exact Coin In With IBC Fees
-        - Sent Asset Not Given, But Valid One Coin
+        - Sent Asset Not Given With Valid One Coin
 
     CW20 Asset
         - User Swap Exact Cw20 Asset In With Transfer
@@ -660,7 +660,7 @@ struct Params {
         ],
         expected_error: None,
     };
-    "Sent Asset Not Given, But Valid One Coin")]
+    "Sent Asset Not Given With Valid One Coin")]
 #[test_case(
     Params {
         info_funds: vec![],

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -69,6 +69,9 @@ Expect Error
     - IBC Transfer With IBC Fees But More Than One IBC Fee Denom Specified
     - IBC Transfer With IBC Fees But No IBC Fee Coins Specified
     - IBC Transfer With IBC Fee Coin Amount Zero
+
+    // Sent Asset
+    - Sent Asset Not Given with Invalid One Coin
  */
 
 // Define test parameters
@@ -1615,6 +1618,32 @@ struct Params {
         expected_error: Some(ContractError::Timeout),
     };
     "Current Block Time Greater Than Timeout Timestamp - Expect Error")]
+#[test_case(
+    Params {
+        info_funds: vec![],
+        sent_asset: None,
+        user_swap: Swap::SwapExactAssetIn (
+            SwapExactAssetIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            }
+        ),
+        min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        timeout_timestamp: 101,
+        post_swap_action: Action::Transfer {
+            to_address: "to_address".to_string(),
+        },
+        affiliates: vec![],
+        expected_messages: vec![],
+        expected_error: Some(ContractError::Payment(NoFunds{})),
+    };
+    "Sent Asset Not Given with Invalid One Coin")]
 fn test_execute_swap_and_action(params: Params) {
     // Create mock dependencies
     let mut deps = mock_dependencies_with_balances(&[(

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -35,6 +35,7 @@ Expect Response
         - User Swap Exact Coin In With IBC Transfer With IBC Fees
         - User Swap Exact Coin In With IBC Transfer Without IBC Fees
         - Fee Swap And User Swap Exact Coin In With IBC Fees
+        - Sent Asset Not Given, But Valid One Coin
 
     CW20 Asset
         - User Swap Exact Cw20 Asset In With Transfer
@@ -583,6 +584,80 @@ struct Params {
         expected_error: None,
     };
     "Fee Swap And User Swap Exact Coin In With IBC Fees")]
+#[test_case(
+    Params {
+        info_funds: vec![
+            Coin::new(1_000_000, "untrn"),
+        ],
+        sent_asset: None,
+        user_swap: Swap::SwapExactAssetIn (
+            SwapExactAssetIn{
+                swap_venue_name: "swap_venue_name".to_string(),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                    }
+                ],
+            }
+        ),
+        min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        timeout_timestamp: 101,
+        post_swap_action: Action::Transfer {
+            to_address: "to_address".to_string(),
+        },
+        affiliates: vec![],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "entry_point".to_string(), 
+                    msg: to_binary(&ExecuteMsg::UserSwap {
+                        swap: Swap::SwapExactAssetIn (
+                            SwapExactAssetIn{
+                                swap_venue_name: "swap_venue_name".to_string(),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "untrn".to_string(),
+                                        denom_out: "osmo".to_string(),
+                                    }
+                                ],
+                            }
+                        ),
+                        remaining_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        affiliates: vec![],
+                    }).unwrap(),
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "entry_point".to_string(), 
+                    msg: to_binary(&ExecuteMsg::PostSwapAction {
+                        min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        timeout_timestamp: 101,
+                        post_swap_action: Action::Transfer {
+                            to_address: "to_address".to_string(),
+                        },
+                        exact_out: false,
+                    }).unwrap(),
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error: None,
+    };
+    "Sent Asset Not Given, But Valid One Coin")]
 #[test_case(
     Params {
         info_funds: vec![],

--- a/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
@@ -18,6 +18,8 @@ Expect Response
     - Happy Path Single Coin
     - Happy Path Multiple Coins
     - Happy Path Cw20 Asset
+    - Sent Asset Not Given With Valid One Coin
+    - Sent Asset Not Given With Invalid One Coin
 
     // Note: The following test case is an invalid call to the contract
     // showing that under the circumstance both coins and a Cw20 token
@@ -197,6 +199,104 @@ struct Params {
         expected_error: None,
     };
     "Happy Path Cw20 Asset")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "untrn")],
+        sent_asset: None,
+        user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            operations: vec![SwapOperation {
+                pool: "pool".to_string(),
+                denom_in: "untrn".to_string(),
+                denom_out: "osmo".to_string(),
+            }],
+        }),
+        min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        timeout_timestamp: 101,
+        post_swap_action: Action::Transfer {
+            to_address: "to_address".to_string(),
+        },
+        affiliates: vec![],
+        expected_assets: vec![Asset::Native(Coin::new(1_000_000, "untrn"))],
+        expected_messages: vec![SubMsg {
+            id: 1,
+            msg: CosmosMsg::from(WasmMsg::Execute {
+                contract_addr: "entry_point".to_string(),
+                msg: to_binary(&ExecuteMsg::SwapAndAction {
+                    sent_asset: None,
+                    user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
+                        swap_venue_name: "swap_venue_name".to_string(),
+                        operations: vec![SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "untrn".to_string(),
+                            denom_out: "osmo".to_string(),
+                        }],
+                    }),
+                    min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                    timeout_timestamp: 101,
+                    post_swap_action: Action::Transfer {
+                        to_address: "to_address".to_string(),
+                    },
+                    affiliates: vec![],
+                })
+                .unwrap(),
+                funds: vec![Coin::new(1000000, "untrn")],
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Always,
+        }],
+        expected_error: None,
+    };
+    "Sent Asset Not Given With Valid One Coin")]
+#[test_case(
+    Params {
+        info_funds: vec![Coin::new(1_000_000, "untrn"), Coin::new(1_000_000, "osmo")],
+        sent_asset: None,
+        user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
+            swap_venue_name: "swap_venue_name".to_string(),
+            operations: vec![SwapOperation {
+                pool: "pool".to_string(),
+                denom_in: "untrn".to_string(),
+                denom_out: "osmo".to_string(),
+            }],
+        }),
+        min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+        timeout_timestamp: 101,
+        post_swap_action: Action::Transfer {
+            to_address: "to_address".to_string(),
+        },
+        affiliates: vec![],
+        expected_assets: vec![Asset::Native(Coin::new(1_000_000, "untrn")), Asset::Native(Coin::new(1_000_000, "osmo"))],
+        expected_messages: vec![SubMsg {
+            id: 1,
+            msg: CosmosMsg::from(WasmMsg::Execute {
+                contract_addr: "entry_point".to_string(),
+                msg: to_binary(&ExecuteMsg::SwapAndAction {
+                    sent_asset: None,
+                    user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
+                        swap_venue_name: "swap_venue_name".to_string(),
+                        operations: vec![SwapOperation {
+                            pool: "pool".to_string(),
+                            denom_in: "untrn".to_string(),
+                            denom_out: "osmo".to_string(),
+                        }],
+                    }),
+                    min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                    timeout_timestamp: 101,
+                    post_swap_action: Action::Transfer {
+                        to_address: "to_address".to_string(),
+                    },
+                    affiliates: vec![],
+                })
+                .unwrap(),
+                funds: vec![Coin::new(1000000, "untrn"), Coin::new(1000000, "osmo")],
+            }),
+            gas_limit: None,
+            reply_on: ReplyOn::Always,
+        }],
+        expected_error: None,
+    };
+    "Sent Asset Not Given With Invalid One Coin")]
 #[test_case(
     Params {
         info_funds: vec![Coin::new(1_000_000, "untrn"), Coin::new(1_000_000, "osmo")],

--- a/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
@@ -29,7 +29,7 @@ Expect Response
 // Define test parameters
 struct Params {
     info_funds: Vec<Coin>,
-    sent_asset: Asset,
+    sent_asset: Option<Asset>,
     user_swap: Swap,
     min_asset: Asset,
     timeout_timestamp: u64,
@@ -44,7 +44,7 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![Coin::new(1_000_000, "untrn")],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
             operations: vec![SwapOperation {
@@ -65,7 +65,7 @@ struct Params {
             msg: CosmosMsg::from(WasmMsg::Execute {
                 contract_addr: "entry_point".to_string(),
                 msg: to_binary(&ExecuteMsg::SwapAndAction {
-                    sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                    sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
                         operations: vec![SwapOperation {
@@ -93,7 +93,7 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![Coin::new(1_000_000, "untrn"), Coin::new(1_000_000, "osmo")],
-        sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+        sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
             operations: vec![SwapOperation {
@@ -114,7 +114,7 @@ struct Params {
             msg: CosmosMsg::from(WasmMsg::Execute {
                 contract_addr: "entry_point".to_string(),
                 msg: to_binary(&ExecuteMsg::SwapAndAction {
-                    sent_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                    sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
                         operations: vec![SwapOperation {
@@ -142,10 +142,10 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![],
-        sent_asset: Asset::Cw20(Cw20Coin{
+        sent_asset: Some(Asset::Cw20(Cw20Coin{
             address: "neutron123".to_string(),
             amount: Uint128::from(1_000_000u128),
-        }),
+        })),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
             operations: vec![SwapOperation {
@@ -169,10 +169,10 @@ struct Params {
             msg: CosmosMsg::from(WasmMsg::Execute {
                 contract_addr: "entry_point".to_string(),
                 msg: to_binary(&ExecuteMsg::SwapAndAction {
-                    sent_asset: Asset::Cw20(Cw20Coin{
+                    sent_asset: Some(Asset::Cw20(Cw20Coin{
                         address: "neutron123".to_string(),
                         amount: Uint128::from(1_000_000u128),
-                    }),
+                    })),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
                         operations: vec![SwapOperation {
@@ -200,10 +200,10 @@ struct Params {
 #[test_case(
     Params {
         info_funds: vec![Coin::new(1_000_000, "untrn"), Coin::new(1_000_000, "osmo")],
-        sent_asset: Asset::Cw20(Cw20Coin{
+        sent_asset: Some(Asset::Cw20(Cw20Coin{
             address: "neutron123".to_string(),
             amount: Uint128::from(1_000_000u128),
-        }),
+        })),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
             operations: vec![SwapOperation {
@@ -227,10 +227,10 @@ struct Params {
             msg: CosmosMsg::from(WasmMsg::Execute {
                 contract_addr: "entry_point".to_string(),
                 msg: to_binary(&ExecuteMsg::SwapAndAction {
-                    sent_asset: Asset::Cw20(Cw20Coin{
+                    sent_asset: Some(Asset::Cw20(Cw20Coin{
                         address: "neutron123".to_string(),
                         amount: Uint128::from(1_000_000u128),
-                    }),
+                    })),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
                         operations: vec![SwapOperation {

--- a/deployed-contracts/neutron/mainnet.toml
+++ b/deployed-contracts/neutron/mainnet.toml
@@ -1,12 +1,12 @@
 [info]
 chain_id = "neutron-1"
 network = "mainnet"
-deploy_date = "06/12/2023 00:12:29"
-commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
+deploy_date = "10/12/2023 23:42:27"
+commit_hash = "9f95ea333f77d9cd602009555e397dfeb08f2958"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
+"skip_api_entry_point-aarch64.wasm" = "a7c050e36f5dd8a101d1def5b58d4b155bb6a88f7fa9c8282a6f8a489a9a8ec4"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
 "skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
@@ -14,15 +14,23 @@ salt = "1"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_neutron-astroport_contract_code_id = "503"
-swap_adapter_neutron-lido-satellite_contract_code_id = "504"
+ibc_transfer_adapter_contract_code_id = "524"
+swap_adapter_neutron-astroport_contract_code_id = "525"
+swap_adapter_neutron-lido-satellite_contract_code_id = "526"
+entry_point_contract_code_id = "527"
 
 [contract-addresses]
-swap_adapter_neutron-astroport_contract_address = "neutron1rfecgx55wwnqmjtm9sq36xkph53xwfhah2uaslq8ghgg2qy66ads99d5cu"
-swap_adapter_neutron-lido-satellite_contract_address = "neutron16whscshfulc2cldxy0xprllvqqu7c4tet6u92qltdd6kjgn0phps67jt7k"
+ibc_transfer_adapter_contract_address = "neutron1x5ss2xz6fw9ctucxrwrs76f99trzwljmpk6wskp9wsdnlv74dhtsx2xt4t"
+swap_adapter_neutron-astroport_contract_address = "neutron1zku6at3gx7q2sydsapw79rnslac6h6rgyk62n43xmkkczvs498ms4jp0hp"
+swap_adapter_neutron-lido-satellite_contract_address = "neutron1frp6t9cnpsuue57aw7ves7pvaxwdcgjseudhp53em3erz80382ps0nlzdc"
+entry_point_contract_address = "neutron1clp46dz247hck0ns5jkv49hqzg8x0vh5hsx8yfvk6w87hnvc6hgsqgc985"
 
 [tx-hashes]
-store_swap_adapter_neutron-astroport_tx_hash = "10a106ecf5c130f3d567581f270a456448664a8e3dfbf60f87c802a76573910a"
-instantiate_swap_adapter_neutron-astroport_tx_hash = "ec9fa5c4fd4fd89d61d19923dd2ca76e82312b6f33ce852a9220a36e54298e8a"
-store_swap_adapter_neutron-lido-satellite_tx_hash = "584597221bbea030029be7c9712ae94fb5a52ec59ccb04c9f3a61b0d5e2375e2"
-instantiate_swap_adapter_neutron-lido-satellite_tx_hash = "fff3715a62ea49c74c2a00ad0fd24dc82da056fedaf45d5cb5bce444f54f7b29"
+store_ibc_transfer_adapter_tx_hash = "651cf0f4c4f021c3a6d83b18491660e21af17a1eefb311e305a5300c872dabaf"
+instantiate_ibc_transfer_adapter_tx_hash = "d012b6a97c2c350b1c7e6bc1f07ebae2f59a8b4ab4e9b5b233bf951a329c368d"
+store_swap_adapter_neutron-astroport_tx_hash = "bb48422d351510019e56cff937eb82adf3ff9e5299a84bd51c5245ed041ea7bf"
+instantiate_swap_adapter_neutron-astroport_tx_hash = "37f62f7261dd0c7a65e8ebc96762ab78fe6610bf01b9ac51dc5810fa881bb141"
+store_swap_adapter_neutron-lido-satellite_tx_hash = "4566c6cb4275795dd69cfd86f4ae8cd8c26c7befe011d038439d2f9779c5ceea"
+instantiate_swap_adapter_neutron-lido-satellite_tx_hash = "a4acab0c10a2868572ba042fe8354c2e36e692f1e9efbfd79fedc2e4923b40df"
+store_entry_point_tx_hash = "96dfcc705e3394c7fd49e54a1a72b69c8fe3f76d5c37667b86bfabefb54b8c89"
+instantiate_entry_point_tx_hash = "3e2451f71c219c0ce74bd1e75887c44ebe9fc6cfca49a335b0f32f8d53889b00"

--- a/deployed-contracts/neutron/testnet.toml
+++ b/deployed-contracts/neutron/testnet.toml
@@ -1,12 +1,12 @@
 [info]
 chain_id = "pion-1"
 network = "testnet"
-deploy_date = "06/12/2023 00:04:49"
-commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
+deploy_date = "10/12/2023 23:37:13"
+commit_hash = "9f95ea333f77d9cd602009555e397dfeb08f2958"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
+"skip_api_entry_point-aarch64.wasm" = "a7c050e36f5dd8a101d1def5b58d4b155bb6a88f7fa9c8282a6f8a489a9a8ec4"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
 "skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
@@ -14,15 +14,23 @@ salt = "1"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_testnet-neutron-astroport_contract_code_id = "2174"
-swap_adapter_testnet-neutron-lido-satellite_contract_code_id = "2175"
+ibc_transfer_adapter_contract_code_id = "2236"
+swap_adapter_testnet-neutron-astroport_contract_code_id = "2237"
+swap_adapter_testnet-neutron-lido-satellite_contract_code_id = "2238"
+entry_point_contract_code_id = "2239"
 
 [contract-addresses]
-swap_adapter_testnet-neutron-astroport_contract_address = "neutron17cmwntfmsp40gt79s8f6sjuxzg4hg7sn3m6ehc76dwr3uz0xt45qn5gvvd"
-swap_adapter_testnet-neutron-lido-satellite_contract_address = "neutron19jgas6ugw53czhk6xd6tp542m0jtgux8tnfa5wwmyju0zz2rv5rsjza0uk"
+ibc_transfer_adapter_contract_address = "neutron1vjt7jh0axvrs5vknzmfzcpztlggtvhxap3kuxf2kekped5cq84fsmcmaxy"
+swap_adapter_testnet-neutron-astroport_contract_address = "neutron1wr0dcsx7plt0jdz62pdqampz5dp6m8enhtekpdnpltzslenuk45s2f4dfk"
+swap_adapter_testnet-neutron-lido-satellite_contract_address = "neutron1aul0fy0y252y3u36kelyz9t6n8pfsjx82xvpcs9wwztq7255q47qxjf7ax"
+entry_point_contract_address = "neutron1clp46dz247hck0ns5jkv49hqzg8x0vh5hsx8yfvk6w87hnvc6hgsqgc985"
 
 [tx-hashes]
-store_swap_adapter_testnet-neutron-astroport_tx_hash = "416ac3dc84c4384b19940021b4b327f68175f960a45aa023611252669ecf02dd"
-instantiate_swap_adapter_testnet-neutron-astroport_tx_hash = "f1e3c1d2f326b527a7ebf6b3abe5b40affc2d52edabf3892fb9eb64a07cb6584"
-store_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "69afd92dccaba0d16d5d218e55e3b395bdde4cf57cb6d49efbce3d8c1adfa427"
-instantiate_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "953258eedf110cf8f4abb913826e43f4fd8a3a8541659d6efdc32ceac67d80a5"
+store_ibc_transfer_adapter_tx_hash = "f23f5d523422490927f1ebb39d2ce928c700fa6c69baefafc67a37449d32838b"
+instantiate_ibc_transfer_adapter_tx_hash = "465a3c62dc84f89fe80e3cd802512fd8728539704f2517962e9a029d7f46372a"
+store_swap_adapter_testnet-neutron-astroport_tx_hash = "d3b995290e816264cce1597841006a53c73de0c4cadc31f0339afe635866ee2b"
+instantiate_swap_adapter_testnet-neutron-astroport_tx_hash = "e1e34b262898e05aaf1527235e325db50d1a3da49784eacd89aabc96f441e24d"
+store_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "8d5e995cd339f04232c023e60975fad219a4a201a2569da144b02b8b4916cbac"
+instantiate_swap_adapter_testnet-neutron-lido-satellite_tx_hash = "63c8ac1d2f49b7613ac47999c08fce7d15d6807cccd3dbe1775e0c6639ccfe41"
+store_entry_point_tx_hash = "b71bbdda7f189f9c0858fddfbbb3f922752e2c069c7ff01fa4b50f0d5426f199"
+instantiate_entry_point_tx_hash = "3f2aa879cc0fa473d8361c24907cdf43fc74e0b1b70fac0aaaa0f5d4d185cb28"

--- a/deployed-contracts/osmosis/mainnet.toml
+++ b/deployed-contracts/osmosis/mainnet.toml
@@ -1,12 +1,12 @@
 [info]
 chain_id = "osmosis-1"
 network = "mainnet"
-deploy_date = "06/12/2023 01:53:21"
-commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
+deploy_date = "10/12/2023 23:48:37"
+commit_hash = "9f95ea333f77d9cd602009555e397dfeb08f2958"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
+"skip_api_entry_point-aarch64.wasm" = "a7c050e36f5dd8a101d1def5b58d4b155bb6a88f7fa9c8282a6f8a489a9a8ec4"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
 "skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
@@ -14,11 +14,19 @@ salt = "1"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_osmosis-poolmanager_contract_code_id = "318"
+ibc_transfer_adapter_contract_code_id = "324"
+swap_adapter_osmosis-poolmanager_contract_code_id = "325"
+entry_point_contract_code_id = "326"
 
 [contract-addresses]
-swap_adapter_osmosis-poolmanager_contract_address = "osmo13tr3xj7vthy56phpcuc2w0kruy9xalgwurz4z9jy3q2m4wxl529sfwt9d0"
+ibc_transfer_adapter_contract_address = "osmo1r90p8aw6tqldwwyzpy8gfgpxu033j8ueum4a6vz8jy6l6vmreygs9emtxg"
+swap_adapter_osmosis-poolmanager_contract_address = "osmo1jca5q6zcjnvhf5v776m8h0xfzqra2y6k6ys9l0y787grc7k44j8swensf6"
+entry_point_contract_address = "osmo1clp46dz247hck0ns5jkv49hqzg8x0vh5hsx8yfvk6w87hnvc6hgs563ew3"
 
 [tx-hashes]
-store_swap_adapter_osmosis-poolmanager_tx_hash = "c41d719113f9025bf4c953b92f61a234c69e543d77859eba7c5118113bbcb8ed"
-instantiate_swap_adapter_osmosis-poolmanager_tx_hash = "6d60594f58f79447bac37a641f96a271119c2e1b2a4c5240c6150006d5b0ffb3"
+store_ibc_transfer_adapter_tx_hash = "61a81e372f43f4dfd367bb54062c93ebcf88e8bd1bf5818c34364ad339886e1a"
+instantiate_ibc_transfer_adapter_tx_hash = "9d3d51377d59009772e1f86d8667340620555b68a6b4321c9e7bce28bf65a1ff"
+store_swap_adapter_osmosis-poolmanager_tx_hash = "443bae0177b66843f2a6cc850dcd9b576952512d81ec69ce3dcccebc52ce6ea8"
+instantiate_swap_adapter_osmosis-poolmanager_tx_hash = "bd616bb006d48e5a5ef1c9563b139c6ce0d8ee8e6411700f589132f765001f14"
+store_entry_point_tx_hash = "e9b2685da821f9d76cfbf3ebd43eab4d046cf84656bcc2784e45964f0408f9cc"
+instantiate_entry_point_tx_hash = "b9e7972a2205a76686cca674d9f0e5486269fe3acd6a53823b13c27e26c35d57"

--- a/deployed-contracts/osmosis/testnet.toml
+++ b/deployed-contracts/osmosis/testnet.toml
@@ -1,12 +1,12 @@
 [info]
 chain_id = "osmo-test-5"
 network = "testnet"
-deploy_date = "06/12/2023 01:47:50"
-commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
+deploy_date = "10/12/2023 23:44:29"
+commit_hash = "9f95ea333f77d9cd602009555e397dfeb08f2958"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
+"skip_api_entry_point-aarch64.wasm" = "a7c050e36f5dd8a101d1def5b58d4b155bb6a88f7fa9c8282a6f8a489a9a8ec4"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
 "skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
@@ -14,11 +14,19 @@ salt = "1"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_testnet-osmosis-poolmanager_contract_code_id = "5454"
+ibc_transfer_adapter_contract_code_id = "5479"
+swap_adapter_testnet-osmosis-poolmanager_contract_code_id = "5480"
+entry_point_contract_code_id = "5481"
 
 [contract-addresses]
-swap_adapter_testnet-osmosis-poolmanager_contract_address = "osmo1q2rhzptx8f9jqvkfuf8e962sqaym5lhh6ep4l4uy5wa89gzttzxqundgdc"
+ibc_transfer_adapter_contract_address = "osmo1av3z6amvryjg6aeguu3m6c8y2nxsca7pk8vsyf6r8uq2mla0jp4qcv6fsd"
+swap_adapter_testnet-osmosis-poolmanager_contract_address = "osmo1yp8qpg5t6azyu7vxxt80ycvnkvmhjvcdrapjthdarna4t3qakevqjgfqa0"
+entry_point_contract_address = "osmo1clp46dz247hck0ns5jkv49hqzg8x0vh5hsx8yfvk6w87hnvc6hgs563ew3"
 
 [tx-hashes]
-store_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "2780cdef30a23743f395eff959ceea724cdb8f8bec7761782f00231ca56a25e7"
-instantiate_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "5f2f9f4abfa6bb63bb78de8af3b58bb6703930e7e8c870b335e1b2aada59c17e"
+store_ibc_transfer_adapter_tx_hash = "6edfefe65ae7d08b765f850738eb8d10d6ef8b9dde03c0d8bd8b2984b5ea251b"
+instantiate_ibc_transfer_adapter_tx_hash = "5766c81403a74a38b6029d81b11419449cc71494a56dcb75d872931e10311480"
+store_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "afa24a05a536b2b68cea0b0506d6ecab153a48cd2564f094ea4d5b0b89b96569"
+instantiate_swap_adapter_testnet-osmosis-poolmanager_tx_hash = "46845b18edaab76417288ed4dc2f70a3279df9b7b4b7bac15c6b53293fcb0bc4"
+store_entry_point_tx_hash = "e92526ef7613a1c9513ca4c47e8b869f6364c92ffb015d629ab558baa2807733"
+instantiate_entry_point_tx_hash = "c2d8e344c817dbc13ed2dfd8ae123dbbd0243efaea61dcfe4eb3c324f5df7c79"

--- a/deployed-contracts/terra/mainnet.toml
+++ b/deployed-contracts/terra/mainnet.toml
@@ -1,12 +1,12 @@
 [info]
 chain_id = "phoenix-1"
 network = "mainnet"
-deploy_date = "06/12/2023 00:45:22"
-commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
+deploy_date = "10/12/2023 23:47:51"
+commit_hash = "9f95ea333f77d9cd602009555e397dfeb08f2958"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
+"skip_api_entry_point-aarch64.wasm" = "a7c050e36f5dd8a101d1def5b58d4b155bb6a88f7fa9c8282a6f8a489a9a8ec4"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
 "skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
@@ -14,11 +14,19 @@ salt = "1"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_terra-astroport_contract_code_id = "2294"
+ibc_transfer_adapter_contract_code_id = "2318"
+swap_adapter_terra-astroport_contract_code_id = "2319"
+entry_point_contract_code_id = "2320"
 
 [contract-addresses]
-swap_adapter_terra-astroport_contract_address = "terra17wf3v0slvh7anc68f3rmz3s3u5x56qhw9yyul94vpcdwmp89fcqqylmvth"
+ibc_transfer_adapter_contract_address = "terra18yzyulzckdt2276p90mqezztl09cpaj2pgy609m4t0wh7kncxmmsxpt8jk"
+swap_adapter_terra-astroport_contract_address = "terra1ymtfmwl9tkdtwr7n6tza0zje364tqk8pn0l5csw573rumutuxm7qfsaxlv"
+entry_point_contract_address = "terra1rguu67l68ngn8mnaczx56c89muflp4z62wkjhm6ugxn0y3j2n22q4wr9ca"
 
 [tx-hashes]
-store_swap_adapter_terra-astroport_tx_hash = "899cc5d6c0b789ead09a17ed554dc27b4fbdf5674d6d5e94373493335985c7fb"
-instantiate_swap_adapter_terra-astroport_tx_hash = "fcf94af30d3227d5dab8b323e568355d76b23b5fd7d152aae2fc0f15cf8dc20c"
+store_ibc_transfer_adapter_tx_hash = "18ee5fe77a265029b9c989d2c3717cefafa9588e64ba367cb1e9922a8217c725"
+instantiate_ibc_transfer_adapter_tx_hash = "b63f70d693d6fad5c46753e7e85812a33a2a77290c0e406ed7d06ef41624e127"
+store_swap_adapter_terra-astroport_tx_hash = "f2be02f53c2c4ba45b3286e831a9bf245b6072f7b93d4deb43093b100c84a091"
+instantiate_swap_adapter_terra-astroport_tx_hash = "648079df7d880059335cc9967bab95f5dfedafc8ddddca51d8e20ab36dc53c08"
+store_entry_point_tx_hash = "3ef8583db3e608f0c78c7c217fd3262f82aab05edbc3cfe24df1f33171a0b081"
+instantiate_entry_point_tx_hash = "3ed8b8f57987078259004f5584a572e9f29e01e1b31cd2723f5993f2c5a89d99"

--- a/deployed-contracts/terra/testnet.toml
+++ b/deployed-contracts/terra/testnet.toml
@@ -1,12 +1,12 @@
 [info]
 chain_id = "pisco-1"
 network = "testnet"
-deploy_date = "06/12/2023 00:43:22"
-commit_hash = "4e6b9a5adaa483717ae96fb83f8df557e2099112"
+deploy_date = "10/12/2023 23:43:57"
+commit_hash = "9f95ea333f77d9cd602009555e397dfeb08f2958"
 salt = "1"
 
 [checksums]
-"skip_api_entry_point-aarch64.wasm" = "3e12c96f85d49e2f3ca7b03af5b6bd766a331faa7ac0af7f1ee13a4c86d04e4a"
+"skip_api_entry_point-aarch64.wasm" = "a7c050e36f5dd8a101d1def5b58d4b155bb6a88f7fa9c8282a6f8a489a9a8ec4"
 "skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "3a102d927b8ccd5f551730ee3454b4fb0f034b73c71cc36af7bf9918b4a79e91"
 "skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e29cf405f43bf4392e44d9ecd534397846eb131c642dd7eef6ce6f93faddf728"
 "skip_api_swap_adapter_astroport-aarch64.wasm" = "c696ee6f3542815d436aa1f12381d4c29fe41ba7bc88773e2abf94a74eb1844f"
@@ -14,11 +14,19 @@ salt = "1"
 "skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "e4f6732d3be7b878e851bc2b9b0d4999088b05e8774540b24b75ea3241ca6438"
 
 [code-ids]
-swap_adapter_testnet-terra-astroport_contract_code_id = "12185"
+ibc_transfer_adapter_contract_code_id = "12311"
+swap_adapter_testnet-terra-astroport_contract_code_id = "12312"
+entry_point_contract_code_id = "12313"
 
 [contract-addresses]
-swap_adapter_testnet-terra-astroport_contract_address = "terra1hn224pg9pepe62d4dlnq9u7jw6s3qdanf4dmujswxsh27l7hz3hq357ue9"
+ibc_transfer_adapter_contract_address = "terra19zfw3682q8yzen22wtyerwweycgp7nwtkq8p25xp7wx4kzps0gvq66m7mt"
+swap_adapter_testnet-terra-astroport_contract_address = "terra187kt9dq3ge0s7ze88zmc8v85tzf207l8mu04pt3pvavlrd6l9hwspx4wy7"
+entry_point_contract_address = "terra1rguu67l68ngn8mnaczx56c89muflp4z62wkjhm6ugxn0y3j2n22q4wr9ca"
 
 [tx-hashes]
-store_swap_adapter_testnet-terra-astroport_tx_hash = "a5d2643c7688448a3851d953dfc3315cb972544149f28f2fa708d87ac1179b53"
-instantiate_swap_adapter_testnet-terra-astroport_tx_hash = "ede1cc1a42ab7d7eb38065a325e954d410af43267c5091352f114fb0611ebb4d"
+store_ibc_transfer_adapter_tx_hash = "d4a1a345b085301630705d8a286c87a0c1810fb0f7a5250b5de0871da2ac4842"
+instantiate_ibc_transfer_adapter_tx_hash = "30ef46d28ba18d01140779314eef1db0cfbc9611f875a1a02bd32ae383a0d422"
+store_swap_adapter_testnet-terra-astroport_tx_hash = "7dbe4d82b3317be6dd0a11252096635fbfc9b0885200bb561ea4893d22b2c21c"
+instantiate_swap_adapter_testnet-terra-astroport_tx_hash = "e5c952a63d93067a3c5cb57c06c32bfc501bd838beddf6f062b4dd2cca8deaed"
+store_entry_point_tx_hash = "93d89d2ccc3c7e025b47c898bd5c01cead41ac2c28b43ca591f13ebc7bc98cc2"
+instantiate_entry_point_tx_hash = "ec0a00bbf43da1c5671730f911644f7567038bfbf0f446479a537060e0d75dea"

--- a/packages/skip/src/entry_point.rs
+++ b/packages/skip/src/entry_point.rs
@@ -30,7 +30,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
     SwapAndActionWithRecover {
-        sent_asset: Asset,
+        sent_asset: Option<Asset>,
         user_swap: Swap,
         min_asset: Asset,
         timeout_timestamp: u64,
@@ -39,7 +39,7 @@ pub enum ExecuteMsg {
         recovery_addr: Addr,
     },
     SwapAndAction {
-        sent_asset: Asset,
+        sent_asset: Option<Asset>,
         user_swap: Swap,
         min_asset: Asset,
         timeout_timestamp: u64,

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -28,7 +28,6 @@
             "min_asset",
             "post_swap_action",
             "recovery_addr",
-            "sent_asset",
             "timeout_timestamp",
             "user_swap"
           ],
@@ -49,7 +48,14 @@
               "$ref": "#/definitions/Addr"
             },
             "sent_asset": {
-              "$ref": "#/definitions/Asset"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Asset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "timeout_timestamp": {
               "type": "integer",
@@ -77,7 +83,6 @@
             "affiliates",
             "min_asset",
             "post_swap_action",
-            "sent_asset",
             "timeout_timestamp",
             "user_swap"
           ],
@@ -95,7 +100,14 @@
               "$ref": "#/definitions/Action"
             },
             "sent_asset": {
-              "$ref": "#/definitions/Asset"
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/Asset"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "timeout_timestamp": {
               "type": "integer",

--- a/schema/skip-api-entry-point.json
+++ b/schema/skip-api-entry-point.json
@@ -73,7 +73,6 @@
               "min_asset",
               "post_swap_action",
               "recovery_addr",
-              "sent_asset",
               "timeout_timestamp",
               "user_swap"
             ],
@@ -94,7 +93,14 @@
                 "$ref": "#/definitions/Addr"
               },
               "sent_asset": {
-                "$ref": "#/definitions/Asset"
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Asset"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "timeout_timestamp": {
                 "type": "integer",
@@ -122,7 +128,6 @@
               "affiliates",
               "min_asset",
               "post_swap_action",
-              "sent_asset",
               "timeout_timestamp",
               "user_swap"
             ],
@@ -140,7 +145,14 @@
                 "$ref": "#/definitions/Action"
               },
               "sent_asset": {
-                "$ref": "#/definitions/Asset"
+                "anyOf": [
+                  {
+                    "$ref": "#/definitions/Asset"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "timeout_timestamp": {
                 "type": "integer",


### PR DESCRIPTION
This PR makes sent_asset param optional. If sent_asset is given, we validate it. If not given, defaulting to enforcing one coin is sent via info.Funds (recover endpoint will still refund if multiple coins given).