### PR TITLE
🚀 [API-2506] Deploy on Sei

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "skip-api-placeholder"
+version = "0.3.0"
+dependencies = [
+ "cosmwasm-std",
+ "cw2 1.1.2",
+]
+
+[[package]]
 name = "skip-api-swap-adapter-astroport"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members  = [
   "contracts/entry-point",
   "contracts/adapters/ibc/*",
   "contracts/adapters/swap/*",
+  "contracts/placeholder",
   "packages/*",
 ]
 

--- a/contracts/adapters/ibc/ibc-hooks/src/contract.rs
+++ b/contracts/adapters/ibc/ibc-hooks/src/contract.rs
@@ -27,8 +27,23 @@ const REPLY_ID: u64 = 1;
 ///////////////
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> ContractResult<Response> {
-    unimplemented!()
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> ContractResult<Response> {
+    // Set contract version
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // Validate entry point contract address
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    // Store the entry point contract address
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "migrate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
 }
 
 ///////////////////

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -42,7 +42,7 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> ContractResult<Resp
     ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
 
     Ok(Response::new()
-        .add_attribute("action", "instantiate")
+        .add_attribute("action", "migrate")
         .add_attribute(
             "entry_point_contract_address",
             checked_entry_point_contract_address.to_string(),

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -21,22 +21,37 @@ use skip::{
     },
 };
 
+// Contract name and version used for migration.
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 ///////////////
 /// MIGRATE ///
 ///////////////
 
 #[cfg_attr(not(feature = "library"), entry_point)]
-pub fn migrate(_deps: DepsMut, _env: Env, _msg: MigrateMsg) -> ContractResult<Response> {
-    unimplemented!()
+pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> ContractResult<Response> {
+    // Set contract version
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    // Validate entry point contract address
+    let checked_entry_point_contract_address =
+        deps.api.addr_validate(&msg.entry_point_contract_address)?;
+
+    // Store the entry point contract address
+    ENTRY_POINT_CONTRACT_ADDRESS.save(deps.storage, &checked_entry_point_contract_address)?;
+
+    Ok(Response::new()
+        .add_attribute("action", "instantiate")
+        .add_attribute(
+            "entry_point_contract_address",
+            checked_entry_point_contract_address.to_string(),
+        ))
 }
 
 ///////////////////
 /// INSTANTIATE ///
 ///////////////////
-
-// Contract name and version used for migration.
-const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(not(feature = "library"), entry_point)]
 pub fn instantiate(

--- a/contracts/placeholder/Cargo.toml
+++ b/contracts/placeholder/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name          = "skip-api-placeholder"
+version       = { workspace = true }
+rust-version  = { workspace = true }
+authors       = { workspace = true }
+edition       = { workspace = true }
+license       = { workspace = true }
+homepage      = { workspace = true }
+repository    = { workspace = true }
+documentation = { workspace = true }
+keywords      = { workspace = true }
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+# for more explicit tests, cargo test --features=backtraces
+backtraces = ["cosmwasm-std/backtraces"]
+# use library feature to disable all instantiate/execute/query exports
+library = []
+
+[dependencies]
+cosmwasm-std     = { workspace = true }
+cw2              = { workspace = true }

--- a/contracts/placeholder/README.md
+++ b/contracts/placeholder/README.md
@@ -1,0 +1,13 @@
+# Placeholder Contract
+
+The Placeholder Contract is a contract that has an instantiate method, and nothing else. The main use case for this contract is to instantiate a specific contract address, later migrating the contract to the real contract desired.
+
+WARNING: Do not send funds directly to the contract without calling one of its functions. Funds sent directly to the contract do not trigger any contract logic that performs validation / safety checks (as the Cosmos SDK handles direct fund transfers in the `Bank` module and not the `Wasm` module). There are no explicit recovery mechanisms for accidentally sent funds.
+
+## InstantiateMsg
+
+Instantiates a new Placeholder contract.
+
+``` json
+{}
+```

--- a/contracts/placeholder/src/contract.rs
+++ b/contracts/placeholder/src/contract.rs
@@ -1,0 +1,23 @@
+use cosmwasm_std::{entry_point, DepsMut, Empty, Env, MessageInfo, Response, StdError};
+use cw2::set_contract_version;
+
+///////////////////
+/// INSTANTIATE ///
+///////////////////
+
+// Contract name and version used for migration.
+const CONTRACT_NAME: &str = env!("CARGO_PKG_NAME");
+const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg_attr(not(feature = "library"), entry_point)]
+pub fn instantiate(
+    deps: DepsMut,
+    _env: Env,
+    _info: MessageInfo,
+    _msg: Empty,
+) -> Result<Response, StdError> {
+    // Set contract version
+    set_contract_version(deps.storage, CONTRACT_NAME, CONTRACT_VERSION)?;
+
+    Ok(Response::new())
+}

--- a/contracts/placeholder/src/lib.rs
+++ b/contracts/placeholder/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod contract;

--- a/deployed-contracts/sei/mainnet.toml
+++ b/deployed-contracts/sei/mainnet.toml
@@ -1,0 +1,38 @@
+[info]
+chain_id = "pacific-1"
+network = "mainnet"
+deploy_date = "07/02/2024 06:34:08"
+commit_hash = "71ab86017859bcb931a2528a72aad5751459b281"
+salt = "1"
+
+[checksums]
+"skip_api_entry_point-aarch64.wasm" = "d18102654c30479b008162010a50a1706f78c1d90914262f135d2507763e5121"
+"skip_api_ibc_adapter_ibc_hooks-aarch64.wasm" = "18f6840c4a121babb2080e2db40d001e0578657d4a3bd55a9db88aaac26f79d9"
+"skip_api_ibc_adapter_neutron_transfer-aarch64.wasm" = "e46f2dc24a2b48ac0dfa9780e131a507ca6dc1230cfc9bba613a76fcb07c1ce2"
+"skip_api_placeholder-aarch64.wasm" = "b8a6cca4e12d1d854ac000082b8d3e6494b6b33e4484bdeeef2ee288adfe71c5"
+"skip_api_swap_adapter_astroport-aarch64.wasm" = "c410d5f2d591eee37aada440202bdf2825442637c25975d8346abc863e0ceb1e"
+"skip_api_swap_adapter_lido_satellite-aarch64.wasm" = "b533260f328631fb73754efb5f7a5469b3f1a462c04fb06f610d7768f1f15820"
+"skip_api_swap_adapter_osmosis_poolmanager-aarch64.wasm" = "677671365aeda46aca42d137b68a850752c5730c81bcea4ca18045e24f591276"
+"skip_api_swap_adapter_white_whale-aarch64.wasm" = "bf8ea53f98139cdbaf2f15cd0267901803b7ccc387af8aca24055453c08f4089"
+
+[code-ids]
+ibc_transfer_adapter_contract_code_id = "2581"
+swap_adapter_sei-astroport_contract_code_id = "2582"
+entry_point_contract_code_id = "2580"
+
+[contract-addresses]
+ibc_transfer_adapter_contract_address = "sei157gyu5uc4tre84hqaavf9hz0uu6lz63w53yk0gpkrmune50dc8gqll66yy"
+swap_adapter_sei-astroport_contract_address = "sei1mhrd5zs576h0f5w4w520kdqu9lqcgp5qnlhnw7sf4yxxeg0uh7nq369mdz"
+entry_point_contract_address = "sei1rmuhl8rdt7ufes9hkzk5dp7pt2cndh0khh5ltlmf25vtgxjl4yhqvae9qd"
+
+[tx-hashes]
+store_ibc_transfer_adapter_tx_hash = "42512407594538e2c0adb4ca124b6f5cfdf47ae40a3e04498058bdc6cce6a8e9"
+instantiate_ibc_transfer_adapter_tx_hash = "54c2e04bbe0dc5959f4b02671b9612b93a70c0285145d5c283e46fa7040c1e2d"
+store_swap_adapter_sei-astroport_tx_hash = "a30cb9b5be0d86a4444064dbfa6c7477190bcd40d4820d9d2e25fc4a5d4011ae"
+instantiate_swap_adapter_sei-astroport_tx_hash = "0218eb5927b8ebcd8c42b05ceeb0d11f4797b807d43c0ae6e3ae4309a9df092b"
+store_entry_point_tx_hash = "46998094b2f169a0bd19abee4dda75d425ec72a1023d8c11dbb3e3e206bb3a1c"
+instantiate_entry_point_tx_hash = "37466d93d76591921ad6bf93fdc6dd78b07b688da19891a83f120d1e9f792f18"
+migrate_ibc_transfer_adapter_tx_hash = "a6661267ff47ca837b2a999dd52a6859573d986e65968821a2f07c13a2d9a5fd"
+update_admin_ibc_transfer_adapter_tx_hash = "63afb0e05e6dda7fc4f1739e15baecc16ff19463b0c3186aea0b2bcb7d86c1d3"
+migrate_swap_adapter_sei-astroport_tx_hash = "dcb13608513ed5f2ecaad4316c85b81032e1d3ebfec1de0164345e602a0a3704"
+update_admin_swap_adapter_sei-astroport_tx_hash = "3dc8d93f0fa946e502933cea21427ae3e9a2838e91c282f8046734fc43dfd60f"

--- a/packages/skip/src/ibc.rs
+++ b/packages/skip/src/ibc.rs
@@ -10,10 +10,11 @@ use neutron_proto::neutron::feerefunder::Fee as NeutronFee;
 /// MIGRATE ///
 ///////////////
 
-// The MigrateMsg struct defines the migration parameters for the entry point contract.
+// The MigrateMsg struct defines the migration parameters used.
 #[cw_serde]
-pub struct MigrateMsg {}
-
+pub struct MigrateMsg {
+    pub entry_point_contract_address: String,
+}
 ///////////////////
 /// INSTANTIATE ///
 ///////////////////

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -15,9 +15,11 @@ use osmosis_std::types::osmosis::poolmanager::v1beta1::{
 /// MIGRATE ///
 ///////////////
 
-// The MigrateMsg struct defines the migration parameters for the entry point contract.
+// The MigrateMsg struct defines the migration parameters used.
 #[cw_serde]
-pub struct MigrateMsg {}
+pub struct MigrateMsg {
+    pub entry_point_contract_address: String,
+}
 
 ///////////////////
 /// INSTANTIATE ///

--- a/scripts/configs/sei.toml
+++ b/scripts/configs/sei.toml
@@ -1,0 +1,43 @@
+# Enter your mnemonic here
+MNEMONIC = "<YOUR MNEMONIC HERE>"
+
+# Commit Hash of the commit used to build the contracts
+COMMIT_HASH = "<COMMIT HASH HERE>"
+
+# Admin address to execute migrations from
+ADMIN_ADDRESS = "<ADMIN ADDRESS HERE>"
+
+MAINNET_REST_URL = "https://sei-api.polkachu.com"
+MAINNET_RPC_URL = "https://sei-rpc.polkachu.com"
+MAINNET_CHAIN_ID = "pacific-1"
+
+TESTNET_REST_URL = "https://sei-testnet-api.polkachu.com"
+TESTNET_RPC_URL = "https://sei-testnet-rpc.polkachu.com"
+TESTNET_CHAIN_ID = "atlantic-2"
+
+ADDRESS_PREFIX = "sei"
+DENOM = "usei"
+GAS_PRICE = 0.1
+
+# Contract Paths
+ENTRY_POINT_CONTRACT_PATH = "../artifacts/skip_api_entry_point-aarch64.wasm"
+IBC_TRANSFER_ADAPTER_PATH = "../artifacts/skip_api_ibc_adapter_ibc_hooks-aarch64.wasm"
+PLACEHOLDER_CONTRACT_PATH = "../artifacts/skip_api_placeholder-aarch64.wasm"
+
+# SALT USED TO GENERATE A DETERMINSTIC ADDRESS
+# NOTE: SEI DOES NOT HAVE INSTANTIATE2, SO THIS IS UNUSED
+SALT = "1"
+
+# @DEV MUST CHANGE SALT ACCORDINGLY TO OBTAIN THIS PRE GENERATED ADDRESS
+# NOTE: SEI DOES NOT HAVE INSTANTIATE2, SO THIS IS UNUSED
+ENTRY_POINT_PRE_GENERATED_ADDRESS = ""
+
+NO_INSTANTIATE2 = true
+
+[[swap_venues]]
+name = "sei-astroport"
+swap_adapter_path = "../artifacts/skip_api_swap_adapter_astroport-aarch64.wasm"
+
+[[testnet_swap_venues]]
+name = "testnet-sei-astroport"
+swap_adapter_path = "../artifacts/skip_api_swap_adapter_astroport-aarch64.wasm"


### PR DESCRIPTION
## This PR
- Deploys our contracts on Sei.

## Details
- Because Sei does not support determinsitic contract addresses (and our contracts depend on having the adapters know the entry point contract address and the entry point address knowing the adapter contract addresses to limit their calling to one another), I did a different method of deployment (changed the configs/deployments so that this can be done on any network without Instantiate2 via config):
1. Created a placeholder contract w/ only an instantiate function to be valid
2. For each adapter contract, store and instantiate a placeholder contract for it, obtaining an address
3. Deploy the entry point contract with the placeholder contract addresses for their respective adapter contract
4. Migrate the placeholder contracts to the real adapter contracts, placing the adapter contracts' instantiate method as the migrate method and storing the now known entry point contract address
5. Updates admin addresses back to the real admin address after migration