### PR TITLE
Update contract types to support route splitting

### DIFF
--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -15,9 +15,10 @@ use cw20::{Cw20Coin, Cw20ReceiveMsg};
 use cw_utils::one_coin;
 use skip::{
     asset::{get_current_asset_available, Asset},
+    error::SkipError,
     swap::{
         execute_transfer_funds_back, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-        Route, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
+        SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 
@@ -101,7 +102,15 @@ pub fn receive_cw20(
     info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
 
     match from_json(&cw20_msg.msg)? {
-        Cw20HookMsg::Swap { routes } => execute_swap(deps, env, info, routes),
+        Cw20HookMsg::Swap { routes } => {
+            if routes.len() != 1 {
+                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
+            }
+
+            let operations = routes.first().unwrap().operations.clone();
+
+            execute_swap(deps, env, info, operations)
+        }
     }
 }
 
@@ -120,7 +129,14 @@ pub fn execute(
         ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
         ExecuteMsg::Swap { routes } => {
             one_coin(&info)?;
-            execute_swap(deps, env, info, routes)
+
+            if routes.len() != 1 {
+                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
+            }
+
+            let operations = routes.first().unwrap().operations.clone();
+
+            execute_swap(deps, env, info, operations)
         }
         ExecuteMsg::TransferFundsBack {
             swapper,
@@ -145,8 +161,7 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    routes: Vec<Route>,
-    // operations: Vec<SwapOperation>,
+    operations: Vec<SwapOperation>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -159,25 +174,20 @@ fn execute_swap(
     // Create a response object to return
     let mut response: Response = Response::new().add_attribute("action", "execute_swap");
 
-    for route in &routes {
-        // Add an astroport pool swap message to the response for each swap operation
-        for operation in &route.operations {
-            let swap_msg = WasmMsg::Execute {
-                contract_addr: env.contract.address.to_string(),
-                msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
-                    operation: operation.clone(),
-                })?,
-                funds: vec![],
-            };
-            response = response.add_message(swap_msg);
-        }
+    // Add an astroport pool swap message to the response for each swap operation
+    for operation in &operations {
+        let swap_msg = WasmMsg::Execute {
+            contract_addr: env.contract.address.to_string(),
+            msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                operation: operation.clone(),
+            })?,
+            funds: vec![],
+        };
+        response = response.add_message(swap_msg);
     }
 
-    let return_denom = match routes.last() {
-        Some(last_route) => match last_route.operations.last() {
-            Some(last_op) => last_op.denom_out.clone(),
-            None => return Err(ContractError::SwapOperationsEmpty),
-        },
+    let return_denom = match operations.last() {
+        Some(last_op) => last_op.denom_out.clone(),
         None => return Err(ContractError::SwapOperationsEmpty),
     };
 

--- a/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use astroport::{
     asset::{Asset as AstroportAsset, AssetInfo},
     pair::{Cw20HookMsg as AstroportPairCw20HookMsg, ExecuteMsg as AstroportPairExecuteMsg},

--- a/contracts/adapters/swap/astroport/tests/test_execute_receive.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_receive.rs
@@ -10,7 +10,7 @@ use cw_utils::PaymentError::NonPayable;
 use skip::{
     asset::Asset,
     error::SkipError::Payment,
-    swap::{ExecuteMsg, SwapOperation},
+    swap::{ExecuteMsg, Route, SwapOperation},
 };
 use skip_api_swap_adapter_astroport::{
     error::{ContractError, ContractResult},
@@ -208,7 +208,10 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
             sender: params.caller,
             amount: params.sent_asset.amount(),
             msg: to_json_binary(&ExecuteMsg::Swap {
-                operations: params.swap_operations,
+                routes: vec![Route {
+                    offer_asset: params.sent_asset,
+                    operations: params.swap_operations,
+                }],
             })
             .unwrap(),
         }),

--- a/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cosmwasm_std::{
     testing::{mock_dependencies, mock_env, mock_info},
     to_json_binary, Addr, Coin,

--- a/contracts/adapters/swap/dexter/src/contract.rs
+++ b/contracts/adapters/swap/dexter/src/contract.rs
@@ -20,8 +20,8 @@ use skip::{
     asset::Asset,
     swap::{
         execute_transfer_funds_back, Cw20HookMsg, DexterAdapterInstantiateMsg, ExecuteMsg,
-        MigrateMsg, QueryMsg, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse,
-        SwapOperation,
+        MigrateMsg, QueryMsg, Route, SimulateSwapExactAssetInResponse,
+        SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 
@@ -101,9 +101,7 @@ pub fn receive_cw20(
     info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
 
     match from_json(&cw20_msg.msg)? {
-        Cw20HookMsg::Swap { operations } => {
-            execute_swap(deps, env, info, sent_asset.amount(), operations)
-        }
+        Cw20HookMsg::Swap { routes } => execute_swap(deps, env, info, sent_asset.amount(), routes),
     }
 }
 
@@ -120,20 +118,20 @@ pub fn execute(
 ) -> ContractResult<Response> {
     match msg {
         ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
-        ExecuteMsg::Swap { operations } => {
+        ExecuteMsg::Swap { routes } => {
             // validate that there's at least one swap operation
-            if operations.is_empty() {
+            if routes.is_empty() || routes.first().unwrap().operations.is_empty() {
                 return Err(ContractError::SwapOperationsEmpty);
             }
 
             let coin = one_coin(&info)?;
 
             // validate that the one coin is the same as the first swap operation's denom in
-            if coin.denom != operations.first().unwrap().denom_in {
+            if coin.denom != routes.first().unwrap().operations.first().unwrap().denom_in {
                 return Err(ContractError::CoinInDenomMismatch);
             }
 
-            execute_swap(deps, env, info, coin.amount, operations)
+            execute_swap(deps, env, info, coin.amount, routes)
         }
         ExecuteMsg::TransferFundsBack {
             swapper,
@@ -156,7 +154,7 @@ fn execute_swap(
     env: Env,
     info: MessageInfo,
     amount_in: Uint128,
-    operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -168,45 +166,52 @@ fn execute_swap(
     }
 
     // Create a response object to return
-    let response: Response = Response::new().add_attribute("action", "execute_swap");
+    let mut response: Response = Response::new().add_attribute("action", "execute_swap");
 
-    let mut hop_swap_requests = vec![];
+    for route in &routes {
+        let mut hop_swap_requests = vec![];
 
-    for operation in &operations {
-        let pool_id: u64 = operation
-            .pool
-            .parse()
-            .map_err(|_| ContractError::PoolIdParseError)?;
-        let pool_id_u128 = Uint128::from(pool_id);
+        for operation in &route.operations {
+            let pool_id: u64 = operation
+                .pool
+                .parse()
+                .map_err(|_| ContractError::PoolIdParseError)?;
+            let pool_id_u128 = Uint128::from(pool_id);
 
-        hop_swap_requests.push(HopSwapRequest {
-            pool_id: pool_id_u128,
-            asset_in: dexter::asset::AssetInfo::native_token(operation.denom_in.clone()),
-            asset_out: dexter::asset::AssetInfo::native_token(operation.denom_out.clone()),
-        });
+            hop_swap_requests.push(HopSwapRequest {
+                pool_id: pool_id_u128,
+                asset_in: dexter::asset::AssetInfo::native_token(operation.denom_in.clone()),
+                asset_out: dexter::asset::AssetInfo::native_token(operation.denom_out.clone()),
+            });
+        }
+
+        let dexter_router_msg = RouterExecuteMsg::ExecuteMultihopSwap {
+            requests: hop_swap_requests,
+            recipient: None,
+            offer_amount: amount_in,
+            // doing this since we would validate it anyway in the entrypoint contract from where swap adapter is called
+            minimum_receive: None,
+        };
+
+        let denom_in = route.operations.first().unwrap().denom_in.clone();
+
+        let dexter_router_wasm_msg = WasmMsg::Execute {
+            contract_addr: dexter_router_contract_address.to_string(),
+            msg: to_json_binary(&dexter_router_msg)?,
+            funds: vec![Coin {
+                denom: denom_in,
+                amount: amount_in,
+            }],
+        };
+
+        response = response.add_message(dexter_router_wasm_msg);
     }
 
-    let dexter_router_msg = RouterExecuteMsg::ExecuteMultihopSwap {
-        requests: hop_swap_requests,
-        recipient: None,
-        offer_amount: amount_in,
-        // doing this since we would validate it anyway in the entrypoint contract from where swap adapter is called
-        minimum_receive: None,
-    };
-
-    let denom_in = operations.first().unwrap().denom_in.clone();
-
-    let dexter_router_wasm_msg = WasmMsg::Execute {
-        contract_addr: dexter_router_contract_address.to_string(),
-        msg: to_json_binary(&dexter_router_msg)?,
-        funds: vec![Coin {
-            denom: denom_in,
-            amount: amount_in,
-        }],
-    };
-
-    let return_denom = match operations.last() {
-        Some(last_op) => last_op.denom_out.clone(),
+    let return_denom = match routes.last() {
+        Some(last_rote) => match last_rote.operations.last() {
+            Some(last_op) => last_op.denom_out.clone(),
+            None => return Err(ContractError::SwapOperationsEmpty),
+        },
         None => return Err(ContractError::SwapOperationsEmpty),
     };
 
@@ -221,7 +226,6 @@ fn execute_swap(
     };
 
     Ok(response
-        .add_message(dexter_router_wasm_msg)
         .add_message(transfer_funds_back_msg)
         .add_attribute("action", "dispatch_swaps_and_transfer_back"))
 }

--- a/contracts/adapters/swap/dexter/src/contract.rs
+++ b/contracts/adapters/swap/dexter/src/contract.rs
@@ -18,10 +18,11 @@ use dexter::{
 };
 use skip::{
     asset::Asset,
+    error::SkipError,
     swap::{
         execute_transfer_funds_back, Cw20HookMsg, DexterAdapterInstantiateMsg, ExecuteMsg,
-        MigrateMsg, QueryMsg, Route, SimulateSwapExactAssetInResponse,
-        SimulateSwapExactAssetOutResponse, SwapOperation,
+        MigrateMsg, QueryMsg, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse,
+        SwapOperation,
     },
 };
 
@@ -101,7 +102,15 @@ pub fn receive_cw20(
     info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
 
     match from_json(&cw20_msg.msg)? {
-        Cw20HookMsg::Swap { routes } => execute_swap(deps, env, info, sent_asset.amount(), routes),
+        Cw20HookMsg::Swap { routes } => {
+            if routes.len() != 1 {
+                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
+            }
+
+            let operations = routes.first().unwrap().operations.clone();
+
+            execute_swap(deps, env, info, sent_asset.amount(), operations)
+        }
     }
 }
 
@@ -119,19 +128,25 @@ pub fn execute(
     match msg {
         ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
         ExecuteMsg::Swap { routes } => {
+            if routes.len() != 1 {
+                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
+            }
+
+            let operations = routes.first().unwrap().operations.clone();
+
             // validate that there's at least one swap operation
-            if routes.is_empty() || routes.first().unwrap().operations.is_empty() {
+            if operations.is_empty() {
                 return Err(ContractError::SwapOperationsEmpty);
             }
 
             let coin = one_coin(&info)?;
 
             // validate that the one coin is the same as the first swap operation's denom in
-            if coin.denom != routes.first().unwrap().operations.first().unwrap().denom_in {
+            if coin.denom != operations.first().unwrap().denom_in {
                 return Err(ContractError::CoinInDenomMismatch);
             }
 
-            execute_swap(deps, env, info, coin.amount, routes)
+            execute_swap(deps, env, info, coin.amount, operations)
         }
         ExecuteMsg::TransferFundsBack {
             swapper,
@@ -154,7 +169,7 @@ fn execute_swap(
     env: Env,
     info: MessageInfo,
     amount_in: Uint128,
-    routes: Vec<Route>,
+    operations: Vec<SwapOperation>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -166,52 +181,45 @@ fn execute_swap(
     }
 
     // Create a response object to return
-    let mut response: Response = Response::new().add_attribute("action", "execute_swap");
+    let response: Response = Response::new().add_attribute("action", "execute_swap");
 
-    for route in &routes {
-        let mut hop_swap_requests = vec![];
+    let mut hop_swap_requests = vec![];
 
-        for operation in &route.operations {
-            let pool_id: u64 = operation
-                .pool
-                .parse()
-                .map_err(|_| ContractError::PoolIdParseError)?;
-            let pool_id_u128 = Uint128::from(pool_id);
+    for operation in &operations {
+        let pool_id: u64 = operation
+            .pool
+            .parse()
+            .map_err(|_| ContractError::PoolIdParseError)?;
+        let pool_id_u128 = Uint128::from(pool_id);
 
-            hop_swap_requests.push(HopSwapRequest {
-                pool_id: pool_id_u128,
-                asset_in: dexter::asset::AssetInfo::native_token(operation.denom_in.clone()),
-                asset_out: dexter::asset::AssetInfo::native_token(operation.denom_out.clone()),
-            });
-        }
-
-        let dexter_router_msg = RouterExecuteMsg::ExecuteMultihopSwap {
-            requests: hop_swap_requests,
-            recipient: None,
-            offer_amount: amount_in,
-            // doing this since we would validate it anyway in the entrypoint contract from where swap adapter is called
-            minimum_receive: None,
-        };
-
-        let denom_in = route.operations.first().unwrap().denom_in.clone();
-
-        let dexter_router_wasm_msg = WasmMsg::Execute {
-            contract_addr: dexter_router_contract_address.to_string(),
-            msg: to_json_binary(&dexter_router_msg)?,
-            funds: vec![Coin {
-                denom: denom_in,
-                amount: amount_in,
-            }],
-        };
-
-        response = response.add_message(dexter_router_wasm_msg);
+        hop_swap_requests.push(HopSwapRequest {
+            pool_id: pool_id_u128,
+            asset_in: dexter::asset::AssetInfo::native_token(operation.denom_in.clone()),
+            asset_out: dexter::asset::AssetInfo::native_token(operation.denom_out.clone()),
+        });
     }
 
-    let return_denom = match routes.last() {
-        Some(last_rote) => match last_rote.operations.last() {
-            Some(last_op) => last_op.denom_out.clone(),
-            None => return Err(ContractError::SwapOperationsEmpty),
-        },
+    let dexter_router_msg = RouterExecuteMsg::ExecuteMultihopSwap {
+        requests: hop_swap_requests,
+        recipient: None,
+        offer_amount: amount_in,
+        // doing this since we would validate it anyway in the entrypoint contract from where swap adapter is called
+        minimum_receive: None,
+    };
+
+    let denom_in = operations.first().unwrap().denom_in.clone();
+
+    let dexter_router_wasm_msg = WasmMsg::Execute {
+        contract_addr: dexter_router_contract_address.to_string(),
+        msg: to_json_binary(&dexter_router_msg)?,
+        funds: vec![Coin {
+            denom: denom_in,
+            amount: amount_in,
+        }],
+    };
+
+    let return_denom = match operations.last() {
+        Some(last_op) => last_op.denom_out.clone(),
         None => return Err(ContractError::SwapOperationsEmpty),
     };
 
@@ -226,6 +234,7 @@ fn execute_swap(
     };
 
     Ok(response
+        .add_message(dexter_router_wasm_msg)
         .add_message(transfer_funds_back_msg)
         .add_attribute("action", "dispatch_swaps_and_transfer_back"))
 }

--- a/contracts/adapters/swap/dexter/tests/integration_test.rs
+++ b/contracts/adapters/swap/dexter/tests/integration_test.rs
@@ -7,7 +7,10 @@ use dexter::{
     vault::{self, FeeInfo, NativeAssetPrecisionInfo},
 };
 use dexter_stable_pool::state::{AssetScalingFactor, StablePoolParams};
-use skip::{asset::Asset, swap::SwapOperation};
+use skip::{
+    asset::Asset,
+    swap::{Route, SwapOperation},
+};
 use utils::{
     instantiate_dexter_contracts_and_pools, instantiate_dexter_swap_adapter_contract,
     DexterInstantiateResponse,
@@ -391,11 +394,17 @@ pub fn test_swap() {
 
     // simulate swap of 1 uxprt to stk/uxprt via 1 pool
     let swap_msg = skip::swap::ExecuteMsg::Swap {
-        operations: vec![SwapOperation {
-            pool: "1".to_string(),
-            denom_in: "uxprt".to_string(),
-            denom_out: "stk/uxprt".to_string(),
-            interface: None,
+        routes: vec![Route {
+            offer_asset: Asset::Native(Coin {
+                denom: "uxprt".to_string(),
+                amount: Uint128::from(1_000_000u128),
+            }),
+            operations: vec![SwapOperation {
+                pool: "1".to_string(),
+                denom_in: "uxprt".to_string(),
+                denom_out: "stk/uxprt".to_string(),
+                interface: None,
+            }],
         }],
     };
 
@@ -439,20 +448,26 @@ pub fn test_swap() {
 
     // perform a swap with multiple pools
     let swap_msg = skip::swap::ExecuteMsg::Swap {
-        operations: vec![
-            SwapOperation {
-                pool: "1".to_string(),
-                denom_in: "uxprt".to_string(),
-                denom_out: "stk/uxprt".to_string(),
-                interface: None,
-            },
-            SwapOperation {
-                pool: "2".to_string(),
-                denom_in: "stk/uxprt".to_string(),
-                denom_out: "stk/uatom".to_string(),
-                interface: None,
-            },
-        ],
+        routes: vec![Route {
+            offer_asset: Asset::Native(Coin {
+                denom: "uxprt".to_string(),
+                amount: Uint128::from(1_000_000u128),
+            }),
+            operations: vec![
+                SwapOperation {
+                    pool: "1".to_string(),
+                    denom_in: "uxprt".to_string(),
+                    denom_out: "stk/uxprt".to_string(),
+                    interface: None,
+                },
+                SwapOperation {
+                    pool: "2".to_string(),
+                    denom_in: "stk/uxprt".to_string(),
+                    denom_out: "stk/uatom".to_string(),
+                    interface: None,
+                },
+            ],
+        }],
     };
 
     // execute the swap

--- a/contracts/adapters/swap/dexter/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/dexter/tests/test_execute_swap.rs
@@ -4,7 +4,10 @@ use cosmwasm_std::{
     ReplyOn::Never,
     SubMsg, Uint128, WasmMsg,
 };
-use skip::swap::{ExecuteMsg, SwapOperation};
+use skip::{
+    asset::Asset,
+    swap::{ExecuteMsg, Route, SwapOperation},
+};
 use skip_api_swap_adapter_dexter::{
     error::ContractResult,
     state::{DEXTER_ROUTER_ADDRESS, DEXTER_VAULT_ADDRESS, ENTRY_POINT_CONTRACT_ADDRESS},
@@ -35,6 +38,7 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
+    offer_asset: Asset,
     swap_operations: Vec<SwapOperation>,
     expected_messages: Vec<SubMsg>,
     expected_error_string: String,
@@ -45,6 +49,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "uxprt")],
+        offer_asset: Asset::Native(Coin::new(100, "uxprt")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -104,6 +109,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -178,6 +184,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![],
         expected_messages: vec![
             SubMsg {
@@ -216,6 +223,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -235,6 +243,7 @@ struct Params {
             Coin::new(100, "os"),
             Coin::new(100, "uatom"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -251,6 +260,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "pool_1".to_string(),
@@ -270,6 +280,7 @@ struct Params {
             Coin::new(100, "uxprt"),
             // Coin::new(100, "os"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "uxprt")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -307,7 +318,10 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            operations: params.swap_operations.clone(),
+            routes: vec![Route {
+                offer_asset: params.offer_asset,
+                operations: params.swap_operations.clone(),
+            }],
         },
     );
 

--- a/contracts/adapters/swap/lido-satellite/src/contract.rs
+++ b/contracts/adapters/swap/lido-satellite/src/contract.rs
@@ -15,8 +15,8 @@ use skip::{
     asset::Asset,
     swap::{
         execute_transfer_funds_back, ExecuteMsg, LidoSatelliteInstantiateMsg as InstantiateMsg,
-        MigrateMsg, QueryMsg, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse,
-        SwapOperation,
+        MigrateMsg, QueryMsg, Route, SimulateSwapExactAssetInResponse,
+        SimulateSwapExactAssetOutResponse,
     },
 };
 
@@ -95,7 +95,7 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> ContractResult<Response> {
     match msg {
-        ExecuteMsg::Swap { operations } => execute_swap(deps, env, info, operations),
+        ExecuteMsg::Swap { routes } => execute_swap(deps, env, info, routes),
         ExecuteMsg::TransferFundsBack {
             swapper,
             return_denom,
@@ -116,7 +116,7 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    _operations: Vec<SwapOperation>,
+    _routes: Vec<Route>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;

--- a/contracts/adapters/swap/lido-satellite/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/lido-satellite/tests/test_execute_swap.rs
@@ -5,7 +5,10 @@ use cosmwasm_std::{
     SubMsg, WasmMsg,
 };
 use lido_satellite::msg::ExecuteMsg as LidoSatelliteExecuteMsg;
-use skip::swap::{ExecuteMsg, SwapOperation};
+use skip::{
+    asset::Asset,
+    swap::{ExecuteMsg, Route, SwapOperation},
+};
 use skip_api_swap_adapter_lido_satellite::{
     error::{ContractError, ContractResult},
     state::{
@@ -34,6 +37,7 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
+    offer_asset: Asset,
     swap_operations: Vec<SwapOperation>,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
@@ -44,6 +48,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "ibc/wstETH")],
+        offer_asset: Asset::Native(Coin::new(100, "ibc/wstETH")),
         swap_operations: vec![],
         expected_messages: vec![
             SubMsg {
@@ -79,6 +84,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "factory/wstETH")],
+        offer_asset: Asset::Native(Coin::new(100, "factory/wstETH")),
         swap_operations: vec![],
         expected_messages: vec![
             SubMsg {
@@ -114,6 +120,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "uosmo")],
+        offer_asset: Asset::Native(Coin::new(100, "uosmo")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::UnsupportedDenom),
@@ -123,6 +130,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
+        offer_asset: Asset::Native(Coin::new(100, "ibc/wstETH")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::NoFunds{})),
@@ -135,6 +143,7 @@ struct Params {
             Coin::new(100, "untrn"),
             Coin::new(100, "uosmo"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "untrn")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::MultipleDenoms{})),
@@ -147,6 +156,7 @@ struct Params {
             Coin::new(100, "untrn"),
             Coin::new(100, "uosmo"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "untrn")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Unauthorized),
@@ -185,7 +195,10 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            operations: params.swap_operations.clone(),
+            routes: vec![Route {
+                offer_asset: params.offer_asset,
+                operations: params.swap_operations.clone(),
+            }],
         },
     );
 

--- a/contracts/adapters/swap/osmosis-poolmanager/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/tests/test_execute_swap.rs
@@ -6,7 +6,10 @@ use cosmwasm_std::{
 };
 use osmosis_std::types::cosmos::base::v1beta1::Coin as OsmosisStdCoin;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{MsgSwapExactAmountIn, SwapAmountInRoute};
-use skip::swap::{ExecuteMsg, SwapOperation};
+use skip::{
+    asset::Asset,
+    swap::{ExecuteMsg, Route, SwapOperation},
+};
 use skip_api_swap_adapter_osmosis_poolmanager::{
     error::ContractResult, state::ENTRY_POINT_CONTRACT_ADDRESS,
 };
@@ -32,6 +35,7 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
+    offer_asset: Asset,
     swap_operations: Vec<SwapOperation>,
     expected_messages: Vec<SubMsg>,
     expected_error_string: String,
@@ -42,6 +46,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -95,6 +100,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "1".to_string(),
@@ -158,6 +164,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![],
         expected_messages: vec![
             SubMsg {
@@ -199,6 +206,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "pool_1".to_string(),
@@ -218,6 +226,7 @@ struct Params {
             Coin::new(100, "os"),
             Coin::new(100, "uatom"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "pool_1".to_string(),
@@ -234,6 +243,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "pool_1".to_string(),
@@ -253,6 +263,7 @@ struct Params {
             Coin::new(100, "untrn"),
             Coin::new(100, "os"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error_string: "Unauthorized".to_string(),
@@ -281,7 +292,10 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            operations: params.swap_operations.clone(),
+            routes: vec![Route {
+                offer_asset: params.offer_asset,
+                operations: params.swap_operations,
+            }],
         },
     );
 

--- a/contracts/adapters/swap/white-whale/src/contract.rs
+++ b/contracts/adapters/swap/white-whale/src/contract.rs
@@ -13,7 +13,7 @@ use skip::{
     asset::{get_current_asset_available, Asset},
     swap::{
         execute_transfer_funds_back, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-        SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
+        Route, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 use white_whale_std::pool_network::{
@@ -89,7 +89,7 @@ pub fn receive_cw20(
     info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
 
     match from_json(&cw20_msg.msg)? {
-        Cw20HookMsg::Swap { operations } => execute_swap(deps, env, info, operations),
+        Cw20HookMsg::Swap { routes } => execute_swap(deps, env, info, routes),
     }
 }
 
@@ -106,9 +106,9 @@ pub fn execute(
 ) -> ContractResult<Response> {
     match msg {
         ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
-        ExecuteMsg::Swap { operations } => {
+        ExecuteMsg::Swap { routes } => {
             one_coin(&info)?;
-            execute_swap(deps, env, info, operations)
+            execute_swap(deps, env, info, routes)
         }
         ExecuteMsg::TransferFundsBack {
             swapper,
@@ -133,7 +133,7 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -146,20 +146,25 @@ fn execute_swap(
     // Create a response object to return
     let mut response: Response = Response::new().add_attribute("action", "execute_swap");
 
-    // Add a white whale pool swap message to the response for each swap operation
-    for operation in &operations {
-        let swap_msg = WasmMsg::Execute {
-            contract_addr: env.contract.address.to_string(),
-            msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
-                operation: operation.clone(),
-            })?,
-            funds: vec![],
-        };
-        response = response.add_message(swap_msg);
+    for route in &routes {
+        // Add a white whale pool swap message to the response for each swap operation
+        for operation in &route.operations {
+            let swap_msg = WasmMsg::Execute {
+                contract_addr: env.contract.address.to_string(),
+                msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                    operation: operation.clone(),
+                })?,
+                funds: vec![],
+            };
+            response = response.add_message(swap_msg);
+        }
     }
 
-    let return_denom = match operations.last() {
-        Some(last_op) => last_op.denom_out.clone(),
+    let return_denom = match routes.last() {
+        Some(last_route) => match last_route.operations.last() {
+            Some(last_op) => last_op.denom_out.clone(),
+            None => return Err(ContractError::SwapOperationsEmpty),
+        },
         None => return Err(ContractError::SwapOperationsEmpty),
     };
 

--- a/contracts/adapters/swap/white-whale/tests/test_execute_receive.rs
+++ b/contracts/adapters/swap/white-whale/tests/test_execute_receive.rs
@@ -10,7 +10,7 @@ use cw_utils::PaymentError::NonPayable;
 use skip::{
     asset::Asset,
     error::SkipError::Payment,
-    swap::{ExecuteMsg, SwapOperation},
+    swap::{ExecuteMsg, Route, SwapOperation},
 };
 use skip_api_swap_adapter_white_whale::{
     error::{ContractError, ContractResult},
@@ -208,7 +208,10 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
             sender: params.caller,
             amount: params.sent_asset.amount(),
             msg: to_json_binary(&ExecuteMsg::Swap {
-                operations: params.swap_operations,
+                routes: vec![Route {
+                    offer_asset: params.sent_asset,
+                    operations: params.swap_operations,
+                }],
             })
             .unwrap(),
         }),

--- a/contracts/adapters/swap/white-whale/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/white-whale/tests/test_execute_swap.rs
@@ -4,7 +4,10 @@ use cosmwasm_std::{
     ReplyOn::Never,
     SubMsg, WasmMsg,
 };
-use skip::swap::{ExecuteMsg, SwapOperation};
+use skip::{
+    asset::Asset,
+    swap::{ExecuteMsg, Route, SwapOperation},
+};
 use skip_api_swap_adapter_white_whale::{
     error::{ContractError, ContractResult},
     state::ENTRY_POINT_CONTRACT_ADDRESS,
@@ -30,6 +33,7 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
+    offer_asset: Asset,
     swap_operations: Vec<SwapOperation>,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
@@ -40,6 +44,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "pool_1".to_string(),
@@ -88,6 +93,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![
             SwapOperation {
                 pool: "pool_1".to_string(),
@@ -159,6 +165,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::SwapOperationsEmpty),
@@ -168,6 +175,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::NoFunds{})),
@@ -180,6 +188,7 @@ struct Params {
             Coin::new(100, "un"),
             Coin::new(100, "os"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "os")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::MultipleDenoms{})),
@@ -191,6 +200,7 @@ struct Params {
         info_funds: vec![
             Coin::new(100, "un"),
         ],
+        offer_asset: Asset::Native(Coin::new(100, "un")),
         swap_operations: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Unauthorized),
@@ -219,7 +229,10 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            operations: params.swap_operations.clone(),
+            routes: vec![Route {
+                offer_asset: params.offer_asset,
+                operations: params.swap_operations,
+            }],
         },
     );
 

--- a/contracts/adapters/swap/white-whale/tests/test_execute_white_whale_pool_swap.rs
+++ b/contracts/adapters/swap/white-whale/tests/test_execute_white_whale_pool_swap.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cosmwasm_std::{
     testing::{mock_dependencies_with_balances, mock_env, mock_info},
     to_json_binary, Addr, Coin, Decimal, QuerierResult,

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use crate::{
     error::{ContractError, ContractResult},
     reply::{RecoverTempStorage, RECOVER_REPLY_ID},
@@ -564,10 +562,6 @@ fn verify_and_create_fee_swap_msg(
     ibc_fee_coin: &Coin,
 ) -> ContractResult<WasmMsg> {
     // Validate swap operations
-    if fee_swap.routes.is_empty() {
-        return Err(ContractError::Skip(SkipError::SwapOperationsEmpty));
-    }
-
     if fee_swap.routes.len() != 1 {
         return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
     }
@@ -575,6 +569,7 @@ fn verify_and_create_fee_swap_msg(
     let operations = fee_swap.routes.first().unwrap().operations.clone();
 
     validate_swap_operations(&operations, remaining_asset.denom(), &ibc_fee_coin.denom)?;
+
     // Get swap adapter contract address from venue name
     let fee_swap_adapter_contract_address =
         SWAP_VENUE_MAP.load(deps.storage, &fee_swap.swap_venue_name)?;

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -568,14 +568,13 @@ fn verify_and_create_fee_swap_msg(
         return Err(ContractError::Skip(SkipError::SwapOperationsEmpty));
     }
 
-    for route in &fee_swap.routes {
-        validate_swap_operations(
-            &route.operations,
-            remaining_asset.denom(),
-            &ibc_fee_coin.denom,
-        )?;
+    if fee_swap.routes.len() != 1 {
+        return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
     }
 
+    let operations = fee_swap.routes.first().unwrap().operations.clone();
+
+    validate_swap_operations(&operations, remaining_asset.denom(), &ibc_fee_coin.denom)?;
     // Get swap adapter contract address from venue name
     let fee_swap_adapter_contract_address =
         SWAP_VENUE_MAP.load(deps.storage, &fee_swap.swap_venue_name)?;

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -324,13 +324,13 @@ pub fn execute_user_swap(
     match swap {
         Swap::SwapExactAssetIn(swap) => {
             // Validate swap operations
-            for route in swap.routes.iter() {
-                validate_swap_operations(
-                    &route.operations,
-                    remaining_asset.denom(),
-                    min_asset.denom(),
-                )?;
+            if swap.routes.len() != 1 {
+                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
             }
+
+            let operations = swap.routes.first().unwrap().operations.clone();
+
+            validate_swap_operations(&operations, remaining_asset.denom(), min_asset.denom())?;
 
             // Get swap adapter contract address from venue name
             let user_swap_adapter_contract_address =
@@ -351,13 +351,13 @@ pub fn execute_user_swap(
         }
         Swap::SwapExactAssetOut(swap) => {
             // Validate swap operations
-            for route in swap.routes.iter() {
-                validate_swap_operations(
-                    &route.operations,
-                    remaining_asset.denom(),
-                    min_asset.denom(),
-                )?;
+            if swap.routes.len() != 1 {
+                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
             }
+
+            let operations = swap.routes.first().unwrap().operations.clone();
+
+            validate_swap_operations(&operations, remaining_asset.denom(), min_asset.denom())?;
 
             // Get swap adapter contract address from venue name
             let user_swap_adapter_contract_address =

--- a/contracts/entry-point/tests/test_execute_receive.rs
+++ b/contracts/entry-point/tests/test_execute_receive.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cosmwasm_std::{
     testing::{mock_dependencies_with_balances, mock_env, mock_info},
     to_json_binary, Addr, Coin, ContractResult, QuerierResult,

--- a/contracts/entry-point/tests/test_execute_receive.rs
+++ b/contracts/entry-point/tests/test_execute_receive.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use cosmwasm_std::{
     testing::{mock_dependencies_with_balances, mock_env, mock_info},
     to_json_binary, Addr, Coin, ContractResult, QuerierResult,
@@ -8,7 +10,7 @@ use cw20::{BalanceResponse, Cw20Coin, Cw20ReceiveMsg};
 use skip::{
     asset::Asset,
     entry_point::{Action, Affiliate, Cw20HookMsg, ExecuteMsg},
-    swap::{Swap, SwapExactAssetIn, SwapOperation},
+    swap::{Route, Swap, SwapExactAssetIn, SwapOperation},
 };
 use skip_api_entry_point::{
     error::ContractError,
@@ -47,14 +49,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route{
+                        offer_asset: Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)}),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -73,14 +80,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "neutron123".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route{
+                                        offer_asset: Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)}),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "neutron123".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)}),
@@ -122,14 +134,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route{
+                        offer_asset: Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)}),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -149,14 +166,19 @@ struct Params {
                         user_swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "neutron123".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Cw20(Cw20Coin{address: "neutron123".to_string(), amount: Uint128::from(1_000_000u128)}),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "neutron123".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -440,7 +440,7 @@ struct Params {
                                                 denom_out: "osmo".to_string(),
                                                 interface: None,
                                             }
-                                        ],                                        
+                                        ],
                                     }
                                 ]
                             }
@@ -504,7 +504,7 @@ struct Params {
                                 denom_out: "uatom".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ]
             },
@@ -537,7 +537,7 @@ struct Params {
                                     denom_out: "untrn".to_string(),
                                     interface: None,
                                 }
-                            ],                            
+                            ],
                         }
                     ],
                     refund_address: None,

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -16,7 +16,8 @@ use skip::{
     },
     ibc::{IbcFee, IbcInfo},
     swap::{
-        ExecuteMsg as SwapExecuteMsg, Swap, SwapExactAssetIn, SwapExactAssetOut, SwapOperation,
+        ExecuteMsg as SwapExecuteMsg, Route, Swap, SwapExactAssetIn, SwapExactAssetOut,
+        SwapOperation,
     },
 };
 use skip_api_entry_point::{
@@ -97,14 +98,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -122,14 +128,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "untrn".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "untrn".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
@@ -173,12 +184,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -199,12 +215,17 @@ struct Params {
                         swap: Swap::SwapExactAssetOut (
                             SwapExactAssetOut{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "untrn".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route{
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "untrn".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
                                 ],
                                 refund_address: Some("refund_address".to_string()),
@@ -251,14 +272,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(800_000, "osmo")),
@@ -298,14 +324,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "untrn".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route{
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "untrn".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Native(Coin::new(800_000, "untrn")),
@@ -361,14 +392,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route{
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -394,14 +430,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "untrn".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "untrn".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],                                        
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
@@ -453,14 +494,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -481,12 +527,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route{
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],                            
                         }
                     ],
                     refund_address: None,
@@ -500,12 +551,17 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "osmo".to_string(),
-                                denom_out: "untrn".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "osmo".to_string(),
+                                        denom_out: "untrn".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
                         ],
                     }).unwrap(),
@@ -533,14 +589,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool_2".to_string(),
-                                        denom_in: "osmo".to_string(),
-                                        denom_out: "uatom".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool_2".to_string(),
+                                                denom_in: "osmo".to_string(),
+                                                denom_out: "uatom".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Native(Coin::new(800_000, "osmo")),
@@ -575,13 +636,18 @@ struct Params {
                             },
                             fee_swap: Some(
                                 SwapExactAssetOut {
-                                    swap_venue_name: "swap_venue_name".to_string(), 
-                                    operations: vec![
-                                        SwapOperation {
-                                            pool: "pool".to_string(),
-                                            denom_in: "osmo".to_string(),
-                                            denom_out: "untrn".to_string(),
-                                            interface: None,
+                                    swap_venue_name: "swap_venue_name".to_string(),                                 
+                                    routes: vec![
+                                        Route {
+                                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                                            operations: vec![
+                                                SwapOperation {
+                                                    pool: "pool".to_string(),
+                                                    denom_in: "osmo".to_string(),
+                                                    denom_out: "untrn".to_string(),
+                                                    interface: None,
+                                                }
+                                            ],
                                         }
                                     ],
                                     refund_address: None,
@@ -609,14 +675,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -634,14 +705,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "untrn".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "untrn".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
@@ -686,14 +762,22 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(1_000_000u128),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -711,14 +795,22 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "neutron123".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Cw20(Cw20Coin {
+                                            address: "neutron123".to_string(),
+                                            amount: Uint128::from(1_000_000u128),
+                                        }),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "neutron123".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Cw20(Cw20Coin {
@@ -766,14 +858,22 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(1_000_000u128),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -794,12 +894,20 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name_2".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "neutron123".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Cw20(Cw20Coin {
+                                address: "neutron123".to_string(),
+                                amount: Uint128::from(1_000_000u128),
+                            }),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "neutron123".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -816,12 +924,20 @@ struct Params {
                         contract: "swap_venue_adapter_2".to_string(), 
                         amount: Uint128::from(200_000u128),
                         msg: to_json_binary(&SwapExecuteMsg::Swap {
-                            operations: vec![
-                                SwapOperation {
-                                    pool: "pool".to_string(),
-                                    denom_in: "neutron123".to_string(),
-                                    denom_out: "untrn".to_string(),
-                                    interface: None,
+                            routes: vec![
+                                Route {
+                                    offer_asset: Asset::Cw20(Cw20Coin {
+                                        address: "neutron123".to_string(),
+                                        amount: Uint128::from(1_000_000u128),
+                                    }),
+                                    operations: vec![
+                                        SwapOperation {
+                                            pool: "pool".to_string(),
+                                            denom_in: "neutron123".to_string(),
+                                            denom_out: "untrn".to_string(),
+                                            interface: None,
+                                        }
+                                    ],
                                 }
                             ],
                         }).unwrap(),
@@ -850,14 +966,22 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool_2".to_string(),
-                                        denom_in: "neutron123".to_string(),
-                                        denom_out: "uatom".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Cw20(Cw20Coin {
+                                            address: "neutron123".to_string(),
+                                            amount: Uint128::from(1_000_000u128),
+                                        }),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "neutron123".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Cw20(Cw20Coin {
@@ -896,12 +1020,20 @@ struct Params {
                             fee_swap: Some(
                                 SwapExactAssetOut {
                                     swap_venue_name: "swap_venue_name_2".to_string(), 
-                                    operations: vec![
-                                        SwapOperation {
-                                            pool: "pool".to_string(),
-                                            denom_in: "neutron123".to_string(),
-                                            denom_out: "untrn".to_string(),
-                                            interface: None,
+                                    routes: vec![
+                                        Route {
+                                            offer_asset: Asset::Cw20(Cw20Coin {
+                                                address: "neutron123".to_string(),
+                                                amount: Uint128::from(1_000_000u128),
+                                            }),
+                                            operations: vec![
+                                                SwapOperation {
+                                                    pool: "pool".to_string(),
+                                                    denom_in: "neutron123".to_string(),
+                                                    denom_out: "untrn".to_string(),
+                                                    interface: None,
+                                                }
+                                            ],
                                         }
                                     ],
                                     refund_address: None,
@@ -929,14 +1061,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         min_asset: Asset::Cw20(Cw20Coin {
@@ -957,14 +1094,19 @@ struct Params {
                         swap: Swap::SwapExactAssetIn (
                             SwapExactAssetIn{
                                 swap_venue_name: "swap_venue_name".to_string(),
-                                operations: vec![
-                                    SwapOperation {
-                                        pool: "pool".to_string(),
-                                        denom_in: "untrn".to_string(),
-                                        denom_out: "osmo".to_string(),
-                                        interface: None,
+                                routes: vec![
+                                    Route {
+                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        operations: vec![
+                                            SwapOperation {
+                                                pool: "pool".to_string(),
+                                                denom_in: "untrn".to_string(),
+                                                denom_out: "osmo".to_string(),
+                                                interface: None,
+                                            }
+                                        ],
                                     }
-                                ],
+                                ]
                             }
                         ),
                         remaining_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
@@ -1014,14 +1156,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(100_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -1042,12 +1189,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(100_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1072,14 +1224,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "uatom")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "uatom".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -1100,12 +1257,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "uatom".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "uatom")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "uatom".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1126,14 +1288,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -1154,12 +1321,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "uatom".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "uatom")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "uatom".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1180,14 +1352,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -1208,12 +1385,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1234,14 +1416,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(800_000, "osmo")),
@@ -1275,14 +1462,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "atom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "atom")),
@@ -1299,12 +1491,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1325,14 +1522,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "atom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "atom")),
@@ -1353,12 +1555,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1379,14 +1586,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "atom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "atom")),
@@ -1407,12 +1619,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1433,14 +1650,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "atom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "atom")),
@@ -1461,12 +1683,17 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![
-                        SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "osmo".to_string(),
-                            denom_out: "untrn".to_string(),
-                            interface: None,
+                    routes: vec![
+                        Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "osmo".to_string(),
+                                    denom_out: "untrn".to_string(),
+                                    interface: None,
+                                }
+                            ],
                         }
                     ],
                     refund_address: None,
@@ -1485,14 +1712,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "osmo".to_string(),
+                                denom_out: "uatom".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -1515,14 +1747,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -1545,14 +1782,22 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(2_000_000u128),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -1575,14 +1820,22 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(1_000_000u128),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -1604,14 +1857,22 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "osmo".to_string(),
-                        denom_out: "uatom".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(1_000_000u128),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         min_asset: Asset::Native(Coin::new(100_000, "uatom")),
@@ -1632,7 +1893,7 @@ struct Params {
             fee_swap: Some(
                 SwapExactAssetOut {
                     swap_venue_name: "swap_venue_name".to_string(), 
-                    operations: vec![],
+                    routes: vec![],
                     refund_address: None,
                 }
             ),
@@ -1651,7 +1912,7 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![],
+                routes: vec![],
             },
         ),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
@@ -1671,12 +1932,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "untrn".to_string(),
-                        denom_out: "osmo".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "untrn".to_string(),
+                                denom_out: "osmo".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
             }

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -11,8 +11,8 @@ use skip::{
     asset::Asset,
     entry_point::{Action, Affiliate, ExecuteMsg},
     error::SkipError::{
-        IbcFeesNotOneCoin, InvalidCw20Coin, Overflow, Payment, SwapOperationsAssetInDenomMismatch,
-        SwapOperationsAssetOutDenomMismatch, SwapOperationsEmpty,
+        IbcFeesNotOneCoin, InvalidCw20Coin, MustBeSingleRoute, Overflow, Payment,
+        SwapOperationsAssetInDenomMismatch, SwapOperationsAssetOutDenomMismatch,
     },
     ibc::{IbcFee, IbcInfo},
     swap::{
@@ -1900,7 +1900,7 @@ struct Params {
         },
         affiliates: vec![],
         expected_messages: vec![],
-        expected_error: Some(ContractError::Skip(SwapOperationsEmpty)),
+        expected_error: Some(ContractError::Skip(MustBeSingleRoute)),
     };
     "Empty Fee Swap Operations - Expect Error")]
 #[test_case(

--- a/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
@@ -1,3 +1,5 @@
+use std::vec;
+
 use cosmwasm_std::{
     testing::{mock_dependencies_with_balances, mock_env, mock_info},
     to_json_binary, Addr, Coin, CosmosMsg, ReplyOn, SubMsg, Timestamp, Uint128, WasmMsg,
@@ -6,7 +8,7 @@ use cw20::Cw20Coin;
 use skip::{
     asset::Asset,
     entry_point::{Action, Affiliate, ExecuteMsg},
-    swap::{Swap, SwapExactAssetIn, SwapOperation},
+    swap::{Route, Swap, SwapExactAssetIn, SwapOperation},
 };
 use skip_api_entry_point::{error::ContractError, state::RECOVER_TEMP_STORAGE};
 use test_case::test_case;
@@ -49,12 +51,17 @@ struct Params {
         sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![SwapOperation {
-                pool: "pool".to_string(),
-                denom_in: "untrn".to_string(),
-                denom_out: "osmo".to_string(),
-                interface: None,
-            }],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                    operations: vec![SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                        interface: None,
+                    }],
+                }
+            ],
         }),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
         timeout_timestamp: 101,
@@ -71,12 +78,17 @@ struct Params {
                     sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
-                        operations: vec![SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "untrn".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
-                        }],
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                operations: vec![SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "untrn".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }],
+                            }
+                        ]
                     }),
                     min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
                     timeout_timestamp: 101,
@@ -100,12 +112,17 @@ struct Params {
         sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![SwapOperation {
-                pool: "pool".to_string(),
-                denom_in: "untrn".to_string(),
-                denom_out: "osmo".to_string(),
-                interface: None,
-            }],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                    operations: vec![SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                        interface: None,
+                    }],
+                }
+            ]
         }),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
         timeout_timestamp: 101,
@@ -122,12 +139,17 @@ struct Params {
                     sent_asset: Some(Asset::Native(Coin::new(1_000_000, "untrn"))),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
-                        operations: vec![SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "untrn".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
-                        }],
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                operations: vec![SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "untrn".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }],
+                            }
+                        ]
                     }),
                     min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
                     timeout_timestamp: 101,
@@ -154,12 +176,20 @@ struct Params {
         })),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![SwapOperation {
-                pool: "pool".to_string(),
-                denom_in: "neutron123".to_string(),
-                denom_out: "osmo".to_string(),
-                interface: None,
-            }],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Cw20(Cw20Coin{
+                        address: "neutron123".to_string(),
+                        amount: Uint128::from(1_000_000u128),
+                    }),
+                    operations: vec![SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "neutron123".to_string(),
+                        denom_out: "osmo".to_string(),
+                        interface: None,
+                    }],
+                }
+            ]
         }),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
         timeout_timestamp: 101,
@@ -182,12 +212,20 @@ struct Params {
                     })),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
-                        operations: vec![SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "neutron123".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
-                        }],
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Cw20(Cw20Coin{
+                                    address: "neutron123".to_string(),
+                                    amount: Uint128::from(1_000_000u128),
+                                }),
+                                operations: vec![SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "neutron123".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }],
+                            }
+                        ]
                     }),
                     min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
                     timeout_timestamp: 101,
@@ -211,12 +249,17 @@ struct Params {
         sent_asset: None,
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![SwapOperation {
-                pool: "pool".to_string(),
-                denom_in: "untrn".to_string(),
-                denom_out: "osmo".to_string(),
-                interface: None,
-            }],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                    operations: vec![SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                        interface: None,
+                    }],
+                }
+            ]
         }),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
         timeout_timestamp: 101,
@@ -233,12 +276,17 @@ struct Params {
                     sent_asset: None,
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
-                        operations: vec![SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "untrn".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
-                        }],
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                operations: vec![SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "untrn".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }],
+                            }
+                        ]
                     }),
                     min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
                     timeout_timestamp: 101,
@@ -262,12 +310,17 @@ struct Params {
         sent_asset: None,
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![SwapOperation {
-                pool: "pool".to_string(),
-                denom_in: "untrn".to_string(),
-                denom_out: "osmo".to_string(),
-                interface: None,
-            }],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                    operations: vec![SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                        interface: None,
+                    }],
+                }
+            ]
         }),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
         timeout_timestamp: 101,
@@ -284,12 +337,17 @@ struct Params {
                     sent_asset: None,
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
-                        operations: vec![SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "untrn".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
-                        }],
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                operations: vec![SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "untrn".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }],
+                            }
+                        ]
                     }),
                     min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
                     timeout_timestamp: 101,
@@ -316,12 +374,20 @@ struct Params {
         })),
         user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
             swap_venue_name: "swap_venue_name".to_string(),
-            operations: vec![SwapOperation {
-                pool: "pool".to_string(),
-                denom_in: "untrn".to_string(),
-                denom_out: "osmo".to_string(),
-                interface: None,
-            }],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Cw20(Cw20Coin{
+                        address: "neutron123".to_string(),
+                        amount: Uint128::from(1_000_000u128),
+                    }),
+                    operations: vec![SwapOperation {
+                        pool: "pool".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "osmo".to_string(),
+                        interface: None,
+                    }],
+                }
+            ]
         }),
         min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
         timeout_timestamp: 101,
@@ -344,12 +410,20 @@ struct Params {
                     })),
                     user_swap: Swap::SwapExactAssetIn(SwapExactAssetIn {
                         swap_venue_name: "swap_venue_name".to_string(),
-                        operations: vec![SwapOperation {
-                            pool: "pool".to_string(),
-                            denom_in: "untrn".to_string(),
-                            denom_out: "osmo".to_string(),
-                            interface: None,
-                        }],
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Cw20(Cw20Coin{
+                                    address: "neutron123".to_string(),
+                                    amount: Uint128::from(1_000_000u128),
+                                }),
+                                operations: vec![SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "untrn".to_string(),
+                                    denom_out: "osmo".to_string(),
+                                    interface: None,
+                                }],
+                            }
+                        ]
                     }),
                     min_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
                     timeout_timestamp: 101,

--- a/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action_with_recover.rs
@@ -1,5 +1,3 @@
-use std::vec;
-
 use cosmwasm_std::{
     testing::{mock_dependencies_with_balances, mock_env, mock_info},
     to_json_binary, Addr, Coin, CosmosMsg, ReplyOn, SubMsg, Timestamp, Uint128, WasmMsg,

--- a/contracts/entry-point/tests/test_user_swap.rs
+++ b/contracts/entry-point/tests/test_user_swap.rs
@@ -248,7 +248,7 @@ struct Params {
                                             denom_out: "os".to_string(),
                                             interface: None,
                                         }
-                                    ],                                    
+                                    ],
                                 }
                             ]
                         }).unwrap(),
@@ -323,7 +323,7 @@ struct Params {
                                     interface: None,
                                 }
                             ],
-                          }  
+                          }
                         ],
                     }).unwrap(),
                     funds: vec![Coin::new(1_000_000, "un")], 
@@ -372,7 +372,7 @@ struct Params {
                                 denom_out: "os".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ]
             }
@@ -494,7 +494,7 @@ struct Params {
                                 denom_out: "os".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -534,7 +534,7 @@ struct Params {
                                         denom_out: "os".to_string(),
                                         interface: None,
                                     }
-                                ],                                
+                                ],
                             }
                         ]
                     }).unwrap(),
@@ -577,7 +577,7 @@ struct Params {
                                 denom_out: "neutron987".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -720,7 +720,7 @@ struct Params {
                                         denom_out: "os".to_string(),
                                         interface: None,
                                     }
-                                ],                                
+                                ],
                             }
                         ]
                     }).unwrap(),
@@ -770,7 +770,7 @@ struct Params {
                                 denom_out: "os".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -840,7 +840,7 @@ struct Params {
                                 denom_out: "os".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -923,7 +923,7 @@ struct Params {
                                 denom_out: "os".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ]
             },
@@ -1110,7 +1110,7 @@ struct Params {
                                 denom_out: "os".to_string(),
                                 interface: None,
                             }
-                        ],                        
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),

--- a/contracts/entry-point/tests/test_user_swap.rs
+++ b/contracts/entry-point/tests/test_user_swap.rs
@@ -14,7 +14,8 @@ use skip::{
         SwapOperationsEmpty,
     },
     swap::{
-        ExecuteMsg as SwapExecuteMsg, Swap, SwapExactAssetIn, SwapExactAssetOut, SwapOperation,
+        ExecuteMsg as SwapExecuteMsg, Route, Swap, SwapExactAssetIn, SwapExactAssetOut,
+        SwapOperation,
     },
 };
 use skip_api_entry_point::{error::ContractError, state::SWAP_VENUE_MAP};
@@ -77,14 +78,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "un")),
@@ -96,14 +102,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(1_000_000, "un")], 
                 }
@@ -121,14 +132,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "un")),
@@ -143,14 +159,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(1_000_000, "un")], 
                 }
@@ -178,12 +199,20 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name_2".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::new(1_000_000),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
             }
@@ -206,14 +235,22 @@ struct Params {
                         contract: "swap_venue_adapter_2".to_string(),
                         amount: Uint128::new(1_000_000),
                         msg: to_json_binary(&SwapExecuteMsg::Swap {
-                            operations: vec![
-                                SwapOperation {
-                                    pool: "pool".to_string(),
-                                    denom_in: "neutron123".to_string(),
-                                    denom_out: "os".to_string(),
-                                    interface: None,
+                            routes: vec![
+                                Route {
+                                    offer_asset: Asset::Cw20(Cw20Coin {
+                                        address: "neutron123".to_string(),
+                                        amount: Uint128::new(1_000_000),
+                                    }),
+                                    operations: vec![
+                                        SwapOperation {
+                                            pool: "pool".to_string(),
+                                            denom_in: "neutron123".to_string(),
+                                            denom_out: "os".to_string(),
+                                            interface: None,
+                                        }
+                                    ],                                    
                                 }
-                            ],
+                            ]
                         }).unwrap(),
                     }).unwrap(),
                     funds: vec![],
@@ -242,14 +279,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             }
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "un")),
@@ -270,13 +312,18 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
-                            }
+                        routes: vec![
+                          Route {
+                            offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                            operations: vec![
+                                SwapOperation {
+                                    pool: "pool".to_string(),
+                                    denom_in: "un".to_string(),
+                                    denom_out: "os".to_string(),
+                                    interface: None,
+                                }
+                            ],
+                          }  
                         ],
                     }).unwrap(),
                     funds: vec![Coin::new(1_000_000, "un")], 
@@ -315,14 +362,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
-                ],
+                ]
             }
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "un")),
@@ -337,14 +389,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(1_000_000, "un")], 
                 }
@@ -362,12 +419,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -392,14 +454,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(500_000, "un")], 
                 }
@@ -417,12 +484,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -452,14 +524,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],                                
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(500_000, "un")], 
                 }
@@ -487,12 +564,20 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name_2".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "neutron987".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::new(1_000_000),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "neutron987".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -533,14 +618,22 @@ struct Params {
                         contract: "swap_venue_adapter_2".to_string(),
                         amount: Uint128::new(500_000),
                         msg: to_json_binary(&SwapExecuteMsg::Swap {
-                            operations: vec![
-                                SwapOperation {
-                                    pool: "pool".to_string(),
-                                    denom_in: "neutron123".to_string(),
-                                    denom_out: "neutron987".to_string(),
-                                    interface: None,
+                            routes: vec![
+                                Route {
+                                    offer_asset: Asset::Cw20(Cw20Coin {
+                                        address: "neutron123".to_string(),
+                                        amount: Uint128::new(1_000_000),
+                                    }),
+                                    operations: vec![
+                                        SwapOperation {
+                                            pool: "pool".to_string(),
+                                            denom_in: "neutron123".to_string(),
+                                            denom_out: "neutron987".to_string(),
+                                            interface: None,
+                                        }
+                                    ],
                                 }
-                            ],
+                            ]
                         }).unwrap(),
                     }).unwrap(),
                     funds: vec![],
@@ -573,12 +666,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -612,14 +710,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],                                
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(500_000, "un")], 
                 }
@@ -657,12 +760,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -692,14 +800,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(500_000, "un")], 
                 }
@@ -717,12 +830,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(500_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -737,14 +855,19 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_venue_adapter".to_string(), 
                     msg: to_json_binary(&SwapExecuteMsg::Swap {
-                        operations: vec![
-                            SwapOperation {
-                                pool: "pool".to_string(),
-                                denom_in: "un".to_string(),
-                                denom_out: "os".to_string(),
-                                interface: None,
+                        routes: vec![
+                            Route {
+                                offer_asset: Asset::Native(Coin::new(500_000, "un")),
+                                operations: vec![
+                                    SwapOperation {
+                                        pool: "pool".to_string(),
+                                        denom_in: "un".to_string(),
+                                        denom_out: "os".to_string(),
+                                        interface: None,
+                                    }
+                                ],
                             }
-                        ],
+                        ]
                     }).unwrap(),
                     funds: vec![Coin::new(500_000, "un")], 
                 }
@@ -762,14 +885,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "ua".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "ua".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
-                ],
+                ]
             },
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "uo")),
@@ -785,14 +913,19 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "uo".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "uo".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
-                ],
+                ]
             },
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "uo")),
@@ -808,7 +941,12 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![],
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![],
+                    }
+                ]
             },
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "un")),
@@ -824,12 +962,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "ua".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "ua".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -848,12 +991,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool_2".to_string(),
-                        denom_in: "os".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "os".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -872,7 +1020,12 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![],
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![],
+                    }
+                ],
                 refund_address: Some("refund_address".to_string()),
             },
         ),
@@ -889,12 +1042,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: None,
@@ -913,12 +1071,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "ua".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "ua".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -937,12 +1100,17 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "un".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "un".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],                        
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -965,12 +1133,20 @@ struct Params {
         user_swap: Swap::SwapExactAssetOut (
             SwapExactAssetOut{
                 swap_venue_name: "swap_venue_name_2".to_string(),
-                operations: vec![
-                    SwapOperation {
-                        pool: "pool".to_string(),
-                        denom_in: "neutron123".to_string(),
-                        denom_out: "os".to_string(),
-                        interface: None,
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::new(1_000_000),
+                        }),
+                        operations: vec![
+                            SwapOperation {
+                                pool: "pool".to_string(),
+                                denom_in: "neutron123".to_string(),
+                                denom_out: "os".to_string(),
+                                interface: None,
+                            }
+                        ],
                     }
                 ],
                 refund_address: Some("refund_address".to_string()),
@@ -996,7 +1172,12 @@ struct Params {
         user_swap: Swap::SwapExactAssetIn (
             SwapExactAssetIn {
                 swap_venue_name: "swap_venue_name".to_string(),
-                operations: vec![],
+                routes: vec![
+                    Route {
+                        offer_asset: Asset::Native(Coin::new(1_000_000, "un")),
+                        operations: vec![],
+                    }
+                ]
             },
         ),
         remaining_asset: Asset::Native(Coin::new(1_000_000, "os")),

--- a/packages/skip/src/error.rs
+++ b/packages/skip/src/error.rs
@@ -32,6 +32,9 @@ pub enum SkipError {
     #[error("Last Swap Operations' Denom Out Differs From Swap Asset Out Denom")]
     SwapOperationsAssetOutDenomMismatch,
 
+    #[error("Routes Must Be Single Route, Multiple Routes Not Supported Yet")]
+    MustBeSingleRoute,
+
     ///////////
     /// IBC ///
     ///////////

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -55,7 +55,7 @@ pub struct LidoSatelliteInstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
-    Swap { operations: Vec<SwapOperation> },
+    Swap { routes: Vec<Route> },
     TransferFundsBack { swapper: Addr, return_denom: String },
     AstroportPoolSwap { operation: SwapOperation }, // Only used for the astroport swap adapter contract
     WhiteWhalePoolSwap { operation: SwapOperation }, // Only used for the white whale swap adapter contract
@@ -63,7 +63,7 @@ pub enum ExecuteMsg {
 
 #[cw_serde]
 pub enum Cw20HookMsg {
-    Swap { operations: Vec<SwapOperation> },
+    Swap { routes: Vec<Route> },
 }
 
 /////////////////////////
@@ -127,6 +127,12 @@ pub struct SimulateSwapExactAssetOutResponse {
 pub struct SwapVenue {
     pub name: String,
     pub adapter_contract_address: String,
+}
+
+#[cw_serde]
+pub struct Route {
+    pub offer_asset: Asset,
+    pub operations: Vec<SwapOperation>,
 }
 
 // Standard swap operation type that contains the pool, denom in, and denom out
@@ -206,12 +212,11 @@ where
 {
     swap_operations.into_iter().map(T::try_from).collect()
 }
-
 // Swap object to get the exact amount of a given asset with the given vector of swap operations
 #[cw_serde]
 pub struct SwapExactAssetOut {
     pub swap_venue_name: String,
-    pub operations: Vec<SwapOperation>,
+    pub routes: Vec<Route>,
     pub refund_address: Option<String>,
 }
 
@@ -220,7 +225,7 @@ pub struct SwapExactAssetOut {
 #[cw_serde]
 pub struct SwapExactAssetIn {
     pub swap_venue_name: String,
-    pub operations: Vec<SwapOperation>,
+    pub routes: Vec<Route>,
 }
 
 // Converts a SwapExactAssetOut used in the entry point contract
@@ -228,7 +233,7 @@ pub struct SwapExactAssetIn {
 impl From<SwapExactAssetOut> for ExecuteMsg {
     fn from(swap: SwapExactAssetOut) -> Self {
         ExecuteMsg::Swap {
-            operations: swap.operations,
+            routes: swap.routes,
         }
     }
 }
@@ -238,7 +243,7 @@ impl From<SwapExactAssetOut> for ExecuteMsg {
 impl From<SwapExactAssetIn> for ExecuteMsg {
     fn from(swap: SwapExactAssetIn) -> Self {
         ExecuteMsg::Swap {
-            operations: swap.operations,
+            routes: swap.routes,
         }
     }
 }

--- a/schema/raw/execute.json
+++ b/schema/raw/execute.json
@@ -446,6 +446,25 @@
       },
       "additionalProperties": false
     },
+    "Route": {
+      "type": "object",
+      "required": [
+        "offer_asset",
+        "operations"
+      ],
+      "properties": {
+        "offer_asset": {
+          "$ref": "#/definitions/Asset"
+        },
+        "operations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SwapOperation"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "Swap": {
       "oneOf": [
         {
@@ -477,14 +496,14 @@
     "SwapExactAssetIn": {
       "type": "object",
       "required": [
-        "operations",
+        "routes",
         "swap_venue_name"
       ],
       "properties": {
-        "operations": {
+        "routes": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/SwapOperation"
+            "$ref": "#/definitions/Route"
           }
         },
         "swap_venue_name": {
@@ -496,21 +515,21 @@
     "SwapExactAssetOut": {
       "type": "object",
       "required": [
-        "operations",
+        "routes",
         "swap_venue_name"
       ],
       "properties": {
-        "operations": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SwapOperation"
-          }
-        },
         "refund_address": {
           "type": [
             "string",
             "null"
           ]
+        },
+        "routes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Route"
+          }
         },
         "swap_venue_name": {
           "type": "string"

--- a/schema/skip-api-entry-point.json
+++ b/schema/skip-api-entry-point.json
@@ -491,6 +491,25 @@
         },
         "additionalProperties": false
       },
+      "Route": {
+        "type": "object",
+        "required": [
+          "offer_asset",
+          "operations"
+        ],
+        "properties": {
+          "offer_asset": {
+            "$ref": "#/definitions/Asset"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/SwapOperation"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
       "Swap": {
         "oneOf": [
           {
@@ -522,14 +541,14 @@
       "SwapExactAssetIn": {
         "type": "object",
         "required": [
-          "operations",
+          "routes",
           "swap_venue_name"
         ],
         "properties": {
-          "operations": {
+          "routes": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/SwapOperation"
+              "$ref": "#/definitions/Route"
             }
           },
           "swap_venue_name": {
@@ -541,21 +560,21 @@
       "SwapExactAssetOut": {
         "type": "object",
         "required": [
-          "operations",
+          "routes",
           "swap_venue_name"
         ],
         "properties": {
-          "operations": {
-            "type": "array",
-            "items": {
-              "$ref": "#/definitions/SwapOperation"
-            }
-          },
           "refund_address": {
             "type": [
               "string",
               "null"
             ]
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/definitions/Route"
+            }
           },
           "swap_venue_name": {
             "type": "string"


### PR DESCRIPTION
This PR updates Skip API contracts to support route splitting by adding a `Route` type:

```
pub struct Route {
    pub offer_asset: Asset,
    pub operations: Vec<SwapOperation>,
}
```

And replacing (most) occurrences of `operations: Vec<SwapOperation>` with `routes: Vec<Route>`

## Note

This only implements the type change and updates the contract and tests to satisfy the new types, some additional work needs to be done to actually support route splitting (for example balances are used throughout the codebase to determine swap amounts, this will no longer work with multiple routes).

## Important Files
- packages/skip/src/swap.rs
- contracts/entry-point/src/execute.rs