### PR TITLE
Support multiple routes in astroport adapter

### DIFF
--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -175,7 +175,7 @@ fn execute_swap(
                 contract_addr: env.contract.address.to_string(),
                 msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
                     operation: operation.clone(),
-                    offer_asset: offer_asset,
+                    offer_asset,
                 })?,
                 funds: vec![],
             };

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -162,8 +162,13 @@ fn execute_swap(
 
     // Add an astroport pool swap message to the response for each swap operation in each route
     for route in &routes {
-        let mut idx = 0;
-        for operation in &route.operations {
+        let enumerated_operations = route
+            .operations
+            .iter()
+            .enumerate()
+            .collect::<Vec<(usize, &SwapOperation)>>();
+
+        for (idx, operation) in enumerated_operations {
             let swap_msg = WasmMsg::Execute {
                 contract_addr: env.contract.address.to_string(),
                 msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
@@ -180,8 +185,6 @@ fn execute_swap(
             };
 
             response = response.add_message(swap_msg);
-
-            idx += 1;
         }
     }
 

--- a/contracts/adapters/swap/astroport/src/contract.rs
+++ b/contracts/adapters/swap/astroport/src/contract.rs
@@ -157,6 +157,9 @@ fn execute_swap(
         return Err(ContractError::Unauthorized);
     }
 
+    // reset the pre swap out asset amount
+    PRE_SWAP_OUT_ASSET_AMOUNT.save(deps.storage, &Uint128::new(0))?;
+
     // Create a response object to return
     let mut response: Response = Response::new().add_attribute("action", "execute_swap");
 

--- a/contracts/adapters/swap/astroport/src/state.rs
+++ b/contracts/adapters/swap/astroport/src/state.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
 
 pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");
+
+pub const PRE_SWAP_OUT_ASSET_AMOUNT: Item<Uint128> = Item::new("pre_swap_out_asset_amount");

--- a/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
@@ -129,7 +129,7 @@ struct Params {
             pool: "pool_1".to_string(),
             denom_in: "os".to_string(),
             denom_out: "ua".to_string(),
-            interface: None, 
+            interface: None,
         },
         expected_message: Some(SubMsg {
             id: 0,

--- a/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
@@ -13,7 +13,10 @@ use skip::{
     asset::Asset,
     swap::{ExecuteMsg, SwapOperation},
 };
-use skip_api_swap_adapter_astroport::error::{ContractError, ContractResult};
+use skip_api_swap_adapter_astroport::{
+    error::{ContractError, ContractResult},
+    state::PRE_SWAP_OUT_ASSET_AMOUNT,
+};
 use test_case::test_case;
 
 /*
@@ -34,6 +37,7 @@ Expect Error
 struct Params {
     caller: String,
     contract_balance: Vec<Coin>,
+    pre_swap_out_asset_amount: Uint128,
     offer_asset: Option<Asset>,
     swap_operation: SwapOperation,
     expected_message: Option<SubMsg>,
@@ -45,6 +49,7 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![Coin::new(100, "os")],
+        pre_swap_out_asset_amount: Uint128::new(0),
         offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
@@ -81,6 +86,7 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        pre_swap_out_asset_amount: Uint128::new(0),
         offer_asset: Some(Asset::Cw20(Cw20Coin {
             address: "neutron123".to_string(),
             amount: Uint128::from(100u128),
@@ -116,7 +122,46 @@ struct Params {
 #[test_case(
     Params {
         caller: "swap_contract_address".to_string(),
+        contract_balance: vec![Coin::new(100, "os")],
+        pre_swap_out_asset_amount: Uint128::new(50),
+        offer_asset: None,
+        swap_operation: SwapOperation {
+            pool: "pool_1".to_string(),
+            denom_in: "os".to_string(),
+            denom_out: "ua".to_string(),
+            interface: None, 
+        },
+        expected_message: Some(SubMsg {
+            id: 0,
+            msg: WasmMsg::Execute {
+                contract_addr: "pool_1".to_string(),
+                msg: to_json_binary(&AstroportPairExecuteMsg::Swap {
+                    offer_asset: AstroportAsset {
+                        info: AssetInfo::NativeToken {
+                            denom: "os".to_string(),
+                        },
+                        amount: Uint128::new(50),
+                    },
+                    ask_asset_info: None,
+                    belief_price: None,
+                    max_spread: Some(Decimal::percent(50)),
+                    to: None,
+                })?,
+                funds: vec![Coin::new(50, "os")],
+            }
+            .into(),
+            gas_limit: None,
+            reply_on: Never
+        }),
+        expected_error: None,
+    };
+    "Deducts pre swap out asset amount from contract balance before swap"
+)]
+#[test_case(
+    Params {
+        caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        pre_swap_out_asset_amount: Uint128::new(0),
         offer_asset: None,
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
@@ -132,6 +177,7 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        pre_swap_out_asset_amount: Uint128::new(0),
         offer_asset: None,
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
@@ -149,6 +195,7 @@ struct Params {
         contract_balance: vec![
             Coin::new(100, "un"),
         ],
+        pre_swap_out_asset_amount: Uint128::new(0),
         offer_asset: Some(Asset::Native(Coin::new(100, "un"))),
         swap_operation: SwapOperation{
             pool: "".to_string(),
@@ -199,6 +246,8 @@ fn test_execute_astroport_pool_swap(params: Params) -> ContractResult<()> {
     // Create mock env
     let mut env = mock_env();
     env.contract.address = Addr::unchecked("swap_contract_address");
+
+    PRE_SWAP_OUT_ASSET_AMOUNT.save(&mut deps.storage, &params.pre_swap_out_asset_amount)?;
 
     // Create mock info
     let info = mock_info(&params.caller, &[]);

--- a/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_astroport_pool_swap.rs
@@ -8,8 +8,11 @@ use cosmwasm_std::{
     ReplyOn::Never,
     SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
 };
-use cw20::{BalanceResponse, Cw20ExecuteMsg};
-use skip::swap::{ExecuteMsg, SwapOperation};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ExecuteMsg};
+use skip::{
+    asset::Asset,
+    swap::{ExecuteMsg, SwapOperation},
+};
 use skip_api_swap_adapter_astroport::error::{ContractError, ContractResult};
 use test_case::test_case;
 
@@ -31,6 +34,7 @@ Expect Error
 struct Params {
     caller: String,
     contract_balance: Vec<Coin>,
+    offer_asset: Option<Asset>,
     swap_operation: SwapOperation,
     expected_message: Option<SubMsg>,
     expected_error: Option<ContractError>,
@@ -41,6 +45,7 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![Coin::new(100, "os")],
+        offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "os".to_string(),
@@ -76,6 +81,10 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        offer_asset: Some(Asset::Cw20(Cw20Coin {
+            address: "neutron123".to_string(),
+            amount: Uint128::from(100u128),
+        })),
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "neutron123".to_string(),
@@ -108,6 +117,7 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        offer_asset: None,
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "os".to_string(),
@@ -122,6 +132,7 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        offer_asset: None,
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "randomcw20".to_string(),
@@ -138,6 +149,7 @@ struct Params {
         contract_balance: vec![
             Coin::new(100, "un"),
         ],
+        offer_asset: Some(Asset::Native(Coin::new(100, "un"))),
         swap_operation: SwapOperation{
             pool: "".to_string(),
             denom_in: "".to_string(),
@@ -197,6 +209,7 @@ fn test_execute_astroport_pool_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::AstroportPoolSwap {
+            offer_asset: params.offer_asset,
             operation: params.swap_operation,
         },
     );

--- a/contracts/adapters/swap/astroport/tests/test_execute_receive.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_receive.rs
@@ -63,6 +63,10 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                        offer_asset: Some(Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(100u128),
+                        })),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "neutron123".to_string(),
@@ -115,6 +119,10 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                        offer_asset: Some(Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(100u128),
+                        })),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "neutron123".to_string(),

--- a/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
@@ -33,8 +33,7 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
-    offer_asset: Asset,
-    swap_operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
 }
@@ -43,14 +42,18 @@ struct Params {
 #[test_case(
     Params {
         caller: "entry_point".to_string(),
-        offer_asset: Asset::Native(Coin::new(100, "os")),
         info_funds: vec![Coin::new(100, "os")],
-        swap_operations: vec![
-            SwapOperation {
-                pool: "pool_1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "ua".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "ua".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![
@@ -59,6 +62,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                        offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "os".to_string(),
@@ -93,19 +97,23 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "pool_1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "ua".to_string(),
-                interface: None,
-            },
-            SwapOperation {
-                pool: "pool_2".to_string(),
-                denom_in: "ua".to_string(),
-                denom_out: "un".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "ua".to_string(),
+                        interface: None,
+                    },
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "ua".to_string(),
+                        denom_out: "un".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![
@@ -114,6 +122,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                        offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "os".to_string(),
@@ -131,6 +140,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                        offer_asset: None,
                         operation: SwapOperation {
                             pool: "pool_2".to_string(),
                             denom_in: "ua".to_string(),
@@ -161,12 +171,123 @@ struct Params {
         expected_error: None,
     };
     "Multiple Swap Operations")]
+    #[test_case(
+        Params {
+            caller: "entry_point".to_string(),
+            info_funds: vec![Coin::new(100, "os")],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Native(Coin::new(25, "os")),
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool_1".to_string(),
+                            denom_in: "os".to_string(),
+                            denom_out: "ua".to_string(),
+                            interface: None,
+                        },
+                        SwapOperation {
+                            pool: "pool_2".to_string(),
+                            denom_in: "ua".to_string(),
+                            denom_out: "un".to_string(),
+                            interface: None,
+                        }
+                    ],
+                },
+                Route {
+                    offer_asset: Asset::Native(Coin::new(75, "os")),
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool_3".to_string(),
+                            denom_in: "os".to_string(),
+                            denom_out: "un".to_string(),
+                            interface: None,
+                        },
+                    ],
+                }                
+            ],
+            expected_messages: vec![
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                            offer_asset: Some(Asset::Native(Coin::new(25, "os"))),
+                            operation: SwapOperation {
+                                pool: "pool_1".to_string(),
+                                denom_in: "os".to_string(),
+                                denom_out: "ua".to_string(),
+                                interface: None,
+                            }
+                        })?,
+                        funds: vec![],
+                    }.into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                            offer_asset: None,
+                            operation: SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "ua".to_string(),
+                                denom_out: "un".to_string(),
+                                interface: None,
+                            }
+                        })?,
+                        funds: vec![],
+                    }.into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::AstroportPoolSwap {
+                            offer_asset: Some(Asset::Native(Coin::new(75, "os"))),
+                            operation: SwapOperation {
+                                pool: "pool_3".to_string(),
+                                denom_in: "os".to_string(),
+                                denom_out: "un".to_string(),
+                                interface: None,
+                            }
+                        })?,
+                        funds: vec![],
+                    }.into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },                
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                            return_denom: "un".to_string(),
+                            swapper: Addr::unchecked("entry_point"),
+                        })?,
+                        funds: vec![],
+                    }
+                    .into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+            ],
+            expected_error: None,
+        };
+        "Multiple Routes")]    
 #[test_case(
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![],
+            }
+        ],
         expected_messages: vec![],
         expected_error: Some(ContractError::SwapOperationsEmpty),
     };
@@ -175,8 +296,7 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        routes: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::NoFunds{})),
     };
@@ -188,8 +308,7 @@ struct Params {
             Coin::new(100, "un"),
             Coin::new(100, "os"),
         ],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        routes: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::MultipleDenoms{})),
     };
@@ -200,8 +319,12 @@ struct Params {
         info_funds: vec![
             Coin::new(100, "un"),
         ],
-        offer_asset: Asset::Native(Coin::new(100, "un")),
-        swap_operations: vec![],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "un")),
+                operations: vec![],
+            }
+        ],
         expected_messages: vec![],
         expected_error: Some(ContractError::Unauthorized),
     };
@@ -229,11 +352,7 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            // operations: params.swap_operations.clone(),
-            routes: vec![Route {
-                offer_asset: params.offer_asset,
-                operations: params.swap_operations,
-            }],
+            routes: params.routes,
         },
     );
 

--- a/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/astroport/tests/test_execute_swap.rs
@@ -171,7 +171,7 @@ struct Params {
         expected_error: None,
     };
     "Multiple Swap Operations")]
-    #[test_case(
+#[test_case(
         Params {
             caller: "entry_point".to_string(),
             info_funds: vec![Coin::new(100, "os")],
@@ -203,7 +203,7 @@ struct Params {
                             interface: None,
                         },
                     ],
-                }                
+                }
             ],
             expected_messages: vec![
                 SubMsg {
@@ -259,7 +259,7 @@ struct Params {
                     }.into(),
                     gas_limit: None,
                     reply_on: Never,
-                },                
+                },
                 SubMsg {
                     id: 0,
                     msg: WasmMsg::Execute {
@@ -277,7 +277,7 @@ struct Params {
             ],
             expected_error: None,
         };
-        "Multiple Routes")]    
+        "Multiple Routes")]
 #[test_case(
     Params {
         caller: "entry_point".to_string(),

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -62,13 +62,15 @@ pub enum ExecuteMsg {
         swapper: Addr,
         return_denom: String,
     },
+    // Only used for the astroport swap adapter contract
     AstroportPoolSwap {
         operation: SwapOperation,
         offer_asset: Option<Asset>,
-    }, // Only used for the astroport swap adapter contract
+    },
+    // Only used for the white whale swap adapter contract
     WhiteWhalePoolSwap {
         operation: SwapOperation,
-    }, // Only used for the white whale swap adapter contract
+    },
 }
 
 #[cw_serde]

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -55,10 +55,20 @@ pub struct LidoSatelliteInstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
-    Swap { routes: Vec<Route> },
-    TransferFundsBack { swapper: Addr, return_denom: String },
-    AstroportPoolSwap { operation: SwapOperation }, // Only used for the astroport swap adapter contract
-    WhiteWhalePoolSwap { operation: SwapOperation }, // Only used for the white whale swap adapter contract
+    Swap {
+        routes: Vec<Route>,
+    },
+    TransferFundsBack {
+        swapper: Addr,
+        return_denom: String,
+    },
+    AstroportPoolSwap {
+        operation: SwapOperation,
+        offer_asset: Option<Asset>,
+    }, // Only used for the astroport swap adapter contract
+    WhiteWhalePoolSwap {
+        operation: SwapOperation,
+    }, // Only used for the white whale swap adapter contract
 }
 
 #[cw_serde]


### PR DESCRIPTION
Updates the Astroport adapter contract to support multiple routes.

The main change is to add an optional `offer_asset` to `AstroportPoolSwap` to allow manually setting the swap amount of an operation. With this we can set the `offer_asset` of a swap operation to the `offer_asset` of the route if it is the first operation in the route.

Most validation we will have to do regarding multiple routes appears to be done in the entry point contract, but correct me if I'm wrong.