### PR TITLE
Support split routes in entry point contract

### DIFF
--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -150,7 +150,7 @@ pub fn execute_swap_and_action(
             // with the largest input amount
             user_swap = match user_swap.clone() {
                 Swap::SwapExactAssetIn(mut swap) => {
-                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+                    let largest_route_idx = get_largest_route_idx(&swap.routes).unwrap_or(0);
 
                     swap.routes[largest_route_idx]
                         .offer_asset
@@ -159,7 +159,7 @@ pub fn execute_swap_and_action(
                     Swap::SwapExactAssetIn(swap)
                 }
                 Swap::SwapExactAssetOut(mut swap) => {
-                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+                    let largest_route_idx = get_largest_route_idx(&swap.routes).unwrap_or(0);
 
                     swap.routes[largest_route_idx]
                         .offer_asset
@@ -185,7 +185,7 @@ pub fn execute_swap_and_action(
             // with the largest input amount
             user_swap = match user_swap.clone() {
                 Swap::SwapExactAssetIn(mut swap) => {
-                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+                    let largest_route_idx = get_largest_route_idx(&swap.routes).unwrap_or(0);
 
                     swap.routes[largest_route_idx]
                         .offer_asset
@@ -194,7 +194,7 @@ pub fn execute_swap_and_action(
                     Swap::SwapExactAssetIn(swap)
                 }
                 Swap::SwapExactAssetOut(mut swap) => {
-                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+                    let largest_route_idx = get_largest_route_idx(&swap.routes).unwrap_or(0);
 
                     swap.routes[largest_route_idx]
                         .offer_asset
@@ -687,25 +687,10 @@ fn query_swap_asset_in(
     Ok(fee_swap_asset_in)
 }
 
-// fn get_largest_route_idx(routes: Vec<Route>) -> usize {
-//     let mut largest_route_idx = 0;
-//     let mut largest_amount = routes[0].offer_asset.amount();
-
-//     routes.into_iter().enumerate().for_each(|(idx, route)| {
-//         if route.offer_asset.amount() > largest_amount {
-//             largest_route_idx = idx;
-//             largest_amount = route.offer_asset.amount();
-//         }
-//     });
-
-//     largest_route_idx
-// }
-
-fn get_largest_route_idx(routes: &[Route]) -> usize {
+fn get_largest_route_idx(routes: &[Route]) -> Option<usize> {
     routes
         .iter()
         .enumerate()
         .max_by_key(|(_, route)| route.offer_asset.amount())
         .map(|(idx, _)| idx)
-        .unwrap()
 }

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -19,7 +19,7 @@ use skip::{
     ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcTransfer},
     swap::{
         validate_routes, validate_swap_operations, ExecuteMsg as SwapExecuteMsg,
-        QueryMsg as SwapQueryMsg, Swap, SwapExactAssetOut,
+        QueryMsg as SwapQueryMsg, Route, Swap, SwapExactAssetOut,
     },
 };
 
@@ -92,7 +92,7 @@ pub fn execute_swap_and_action(
     env: Env,
     info: MessageInfo,
     sent_asset: Option<Asset>,
-    user_swap: Swap,
+    mut user_swap: Swap,
     min_asset: Asset,
     timeout_timestamp: u64,
     post_swap_action: Action,
@@ -139,12 +139,35 @@ pub fn execute_swap_and_action(
                 .ok_or(ContractError::FeeSwapWithoutIbcFees)?;
 
             // NOTE: this call mutates remaining_asset by deducting ibc_fee_coin's amount from it
-            let fee_swap_msg = verify_and_create_fee_swap_msg(
+            let (fee_swap_msg, fee_swap_asset_in) = verify_and_create_fee_swap_msg(
                 &deps,
                 fee_swap,
                 &mut remaining_asset,
                 &ibc_fee_coin,
             )?;
+
+            // Update the user swap to deduct the ibc fee amount from the route
+            // with the largest input amount
+            user_swap = match user_swap.clone() {
+                Swap::SwapExactAssetIn(mut swap) => {
+                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+
+                    swap.routes[largest_route_idx]
+                        .offer_asset
+                        .sub(fee_swap_asset_in.amount())?;
+
+                    Swap::SwapExactAssetIn(swap)
+                }
+                Swap::SwapExactAssetOut(mut swap) => {
+                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+
+                    swap.routes[largest_route_idx]
+                        .offer_asset
+                        .sub(fee_swap_asset_in.amount())?;
+
+                    Swap::SwapExactAssetOut(swap)
+                }
+            };
 
             // Add the fee swap message to the response
             response = response
@@ -157,6 +180,29 @@ pub fn execute_swap_and_action(
 
             // Deduct the ibc_fee_coin amount from the remaining asset amount
             remaining_asset.sub(ibc_fee_coin.amount)?;
+
+            // Update the user swap to deduct the ibc fee amount from the route
+            // with the largest input amount
+            user_swap = match user_swap.clone() {
+                Swap::SwapExactAssetIn(mut swap) => {
+                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+
+                    swap.routes[largest_route_idx]
+                        .offer_asset
+                        .sub(ibc_fee_coin.amount)?;
+
+                    Swap::SwapExactAssetIn(swap)
+                }
+                Swap::SwapExactAssetOut(mut swap) => {
+                    let largest_route_idx = get_largest_route_idx(&swap.routes);
+
+                    swap.routes[largest_route_idx]
+                        .offer_asset
+                        .sub(ibc_fee_coin.amount)?;
+
+                    Swap::SwapExactAssetOut(swap)
+                }
+            };
         }
 
         // Dispatch the ibc fee bank send to the ibc transfer adapter contract if needed
@@ -554,7 +600,7 @@ fn verify_and_create_fee_swap_msg(
     fee_swap: &SwapExactAssetOut,
     remaining_asset: &mut Asset,
     ibc_fee_coin: &Coin,
-) -> ContractResult<WasmMsg> {
+) -> ContractResult<(WasmMsg, Asset)> {
     // Validate swap operations
     if fee_swap.routes.len() != 1 {
         return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
@@ -589,12 +635,12 @@ fn verify_and_create_fee_swap_msg(
     let fee_swap_msg_args: SwapExecuteMsg = fee_swap.clone().into();
 
     // Create the fee swap message
-    let fee_swap_msg = fee_swap_asset_in.into_wasm_msg(
+    let fee_swap_msg = fee_swap_asset_in.clone().into_wasm_msg(
         fee_swap_adapter_contract_address.to_string(),
         to_json_binary(&fee_swap_msg_args)?,
     )?;
 
-    Ok(fee_swap_msg)
+    Ok((fee_swap_msg, fee_swap_asset_in))
 }
 
 // AFFILIATE FEE HELPER FUNCTIONS
@@ -639,4 +685,27 @@ fn query_swap_asset_in(
     )?;
 
     Ok(fee_swap_asset_in)
+}
+
+// fn get_largest_route_idx(routes: Vec<Route>) -> usize {
+//     let mut largest_route_idx = 0;
+//     let mut largest_amount = routes[0].offer_asset.amount();
+
+//     routes.into_iter().enumerate().for_each(|(idx, route)| {
+//         if route.offer_asset.amount() > largest_amount {
+//             largest_route_idx = idx;
+//             largest_amount = route.offer_asset.amount();
+//         }
+//     });
+
+//     largest_route_idx
+// }
+
+fn get_largest_route_idx(routes: &[Route]) -> usize {
+    routes
+        .iter()
+        .enumerate()
+        .max_by_key(|(_, route)| route.offer_asset.amount())
+        .map(|(idx, _)| idx)
+        .unwrap()
 }

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -18,8 +18,8 @@ use skip::{
     error::SkipError,
     ibc::{ExecuteMsg as IbcTransferExecuteMsg, IbcTransfer},
     swap::{
-        validate_swap_operations, ExecuteMsg as SwapExecuteMsg, QueryMsg as SwapQueryMsg, Swap,
-        SwapExactAssetOut,
+        validate_routes, validate_swap_operations, ExecuteMsg as SwapExecuteMsg,
+        QueryMsg as SwapQueryMsg, Swap, SwapExactAssetOut,
     },
 };
 
@@ -321,14 +321,8 @@ pub fn execute_user_swap(
     // Create the user swap message
     match swap {
         Swap::SwapExactAssetIn(swap) => {
-            // Validate swap operations
-            if swap.routes.len() != 1 {
-                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
-            }
-
-            let operations = swap.routes.first().unwrap().operations.clone();
-
-            validate_swap_operations(&operations, remaining_asset.denom(), min_asset.denom())?;
+            // Validate routes
+            validate_routes(&swap.routes, &remaining_asset, min_asset.denom())?;
 
             // Get swap adapter contract address from venue name
             let user_swap_adapter_contract_address =

--- a/contracts/entry-point/tests/test_execute_swap_and_action.rs
+++ b/contracts/entry-point/tests/test_execute_swap_and_action.rs
@@ -326,7 +326,7 @@ struct Params {
                                 swap_venue_name: "swap_venue_name".to_string(),
                                 routes: vec![
                                     Route{
-                                        offer_asset: Asset::Native(Coin::new(1_000_000, "untrn")),
+                                        offer_asset: Asset::Native(Coin::new(800_000, "untrn")),
                                         operations: vec![
                                             SwapOperation {
                                                 pool: "pool".to_string(),
@@ -591,7 +591,7 @@ struct Params {
                                 swap_venue_name: "swap_venue_name".to_string(),
                                 routes: vec![
                                     Route {
-                                        offer_asset: Asset::Native(Coin::new(1_000_000, "osmo")),
+                                        offer_asset: Asset::Native(Coin::new(800_000, "osmo")),
                                         operations: vec![
                                             SwapOperation {
                                                 pool: "pool_2".to_string(),
@@ -970,7 +970,7 @@ struct Params {
                                     Route {
                                         offer_asset: Asset::Cw20(Cw20Coin {
                                             address: "neutron123".to_string(),
-                                            amount: Uint128::from(1_000_000u128),
+                                            amount: Uint128::from(800_000u128),
                                         }),
                                         operations: vec![
                                             SwapOperation {

--- a/contracts/entry-point/tests/test_user_swap.rs
+++ b/contracts/entry-point/tests/test_user_swap.rs
@@ -10,8 +10,9 @@ use skip::{
     asset::Asset,
     entry_point::{Affiliate, ExecuteMsg},
     error::SkipError::{
-        Overflow, SwapOperationsAssetInDenomMismatch, SwapOperationsAssetOutDenomMismatch,
-        SwapOperationsEmpty, MustBeSingleRoute, RoutesAssetInAmountMismatch
+        MustBeSingleRoute, Overflow, RoutesAssetInAmountMismatch,
+        SwapOperationsAssetInDenomMismatch, SwapOperationsAssetOutDenomMismatch,
+        SwapOperationsEmpty,
     },
     swap::{
         ExecuteMsg as SwapExecuteMsg, Route, Swap, SwapExactAssetIn, SwapExactAssetOut,
@@ -915,9 +916,9 @@ struct Params {
                                 denom_in: "ua".to_string(),
                                 denom_out: "os".to_string(),
                                 interface: None,
-                            }                            
+                            }
                         ],
-                    }                    
+                    }
                 ],
             }
         ),
@@ -956,9 +957,9 @@ struct Params {
                                         denom_in: "ua".to_string(),
                                         denom_out: "os".to_string(),
                                         interface: None,
-                                    }                            
+                                    }
                                 ],
-                            }                    
+                            }
                         ],
                     }).unwrap(),
                     funds: vec![Coin::new(1_000_000, "un")],
@@ -1306,9 +1307,9 @@ struct Params {
                                 denom_in: "ua".to_string(),
                                 denom_out: "os".to_string(),
                                 interface: None,
-                            },                   
+                            },
                         ],
-                    }                    
+                    }
                 ],
             }
         ),
@@ -1346,9 +1347,9 @@ struct Params {
                                 denom_in: "un".to_string(),
                                 denom_out: "ua".to_string(),
                                 interface: None,
-                            },                   
+                            },
                         ],
-                    }                    
+                    }
                 ],
             }
         ),
@@ -1392,9 +1393,9 @@ struct Params {
                                 denom_in: "ua".to_string(),
                                 denom_out: "os".to_string(),
                                 interface: None,
-                            }                            
+                            }
                         ],
-                    }                    
+                    }
                 ],
             }
         ),
@@ -1434,7 +1435,7 @@ struct Params {
                                 interface: None,
                             }
                         ],
-                    }                    
+                    }
                 ],
                 refund_address: Some("refund_address".to_string()),
             }

--- a/packages/skip/src/error.rs
+++ b/packages/skip/src/error.rs
@@ -32,8 +32,18 @@ pub enum SkipError {
     #[error("Last Swap Operations' Denom Out Differs From Swap Asset Out Denom")]
     SwapOperationsAssetOutDenomMismatch,
 
+    //////////////
+    /// ROUTE ///
+    ////////////
+
     #[error("Routes Must Be Single Route, Multiple Routes Not Supported Yet")]
     MustBeSingleRoute,
+
+    #[error("Routes Empty")]
+    RoutesEmpty,
+
+    #[error("Total Routes Asset In Amount Differs From Swap Asset In Amount")]
+    RoutesAssetInAmountMismatch,
 
     ///////////
     /// IBC ///

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -4,8 +4,8 @@ use std::{convert::TryFrom, num::ParseIntError};
 
 use astroport::{asset::AssetInfo, router::SwapOperation as AstroportSwapOperation};
 use cosmwasm_schema::{cw_serde, QueryResponses};
-use cosmwasm_std::Binary;
 use cosmwasm_std::{Addr, Api, BankMsg, CosmosMsg, Decimal, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{Binary, Uint128};
 use cw20::Cw20Contract;
 use cw20::Cw20ReceiveMsg;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
@@ -308,6 +308,34 @@ pub fn validate_swap_operations(
     // Verify the last swap operation denom out is the same as the asset out denom
     if last_op.denom_out != asset_out_denom {
         return Err(SkipError::SwapOperationsAssetOutDenomMismatch);
+    }
+
+    Ok(())
+}
+
+// Validates routes
+pub fn validate_routes(
+    routes: &[Route],
+    asset_in: &Asset,
+    asset_out_denom: &str,
+) -> Result<(), SkipError> {
+    // Verify the routes are not empty
+    if routes.is_empty() {
+        return Err(SkipError::RoutesEmpty);
+    }
+
+    let mut amount_in = Uint128::zero();
+
+    for route in routes {
+        // Verify the swap operations are not empty, and all operations have the same denom in and out
+        validate_swap_operations(&route.operations, asset_in.denom(), asset_out_denom)?;
+
+        amount_in += route.offer_asset.amount();
+    }
+
+    // Verify the total offer_asset amount is equal to the asset_in amount
+    if amount_in != asset_in.amount() {
+        return Err(SkipError::RoutesAssetInAmountMismatch);
     }
 
     Ok(())


### PR DESCRIPTION
Updates the Entry Point contract to support multiple routes when calling `SwapExactAssetIn`.

`SwapExactAssetOut` will continue to be unsupported for the time being due to added complexity and no current integrators supporting this anyways.