### PR TITLE
Add split route support in all adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,15 +939,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "osmosis-std"
-version = "0.15.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87725a7480b98887167edf878daa52201a13322ad88e34355a7f2ddc663e047e"
+checksum = "30a7a605885934d9bcfcd544f4e2098365725974522cbf8d696f65c5bb8047b3"
 dependencies = [
  "chrono",
  "cosmwasm-std",
- "osmosis-std-derive",
- "prost 0.11.9",
- "prost-types 0.11.9",
+ "osmosis-std-derive 0.20.1",
+ "prost 0.12.3",
+ "prost-types 0.12.3",
  "schemars",
  "serde",
  "serde-cw-value",
@@ -961,6 +961,19 @@ checksum = "f4d482a16be198ee04e0f94e10dd9b8d02332dcf33bc5ea4b255e7e25eedc5df"
 dependencies = [
  "itertools 0.10.5",
  "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "osmosis-std-derive"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ebdfd1bc8ed04db596e110c6baa9b174b04f6ed1ec22c666ddc5cb3fa91bd7"
+dependencies = [
+ "itertools 0.10.5",
+ "proc-macro2",
+ "prost-types 0.11.9",
  "quote",
  "syn 1.0.109",
 ]
@@ -1725,7 +1738,7 @@ dependencies = [
  "cosmwasm-std",
  "cw2 1.1.2",
  "cw20 1.1.2",
- "osmosis-std-derive",
+ "osmosis-std-derive 0.15.3",
  "prost 0.11.9",
  "prost-types 0.11.9",
  "protobuf 3.3.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ ibc-proto        = { version = "0.32.1", default-features = false }
 lido-satellite   = { git = "https://github.com/hadronlabs-org/lido-satellite", branch = "main", features = ["library"] }
 neutron-proto    = { version = "0.1.1", default-features = false, features = ["cosmwasm"] }
 neutron-sdk      = "0.8"
-osmosis-std      = "0.15.3"
+osmosis-std      = "0.24.0"
 prost            = "0.11"
 serde-cw-value   = "0.7.0"
 serde-json-wasm  = "0.5.1"

--- a/contracts/adapters/swap/dexter/src/contract.rs
+++ b/contracts/adapters/swap/dexter/src/contract.rs
@@ -18,11 +18,10 @@ use dexter::{
 };
 use skip::{
     asset::Asset,
-    error::SkipError,
     swap::{
         execute_transfer_funds_back, Cw20HookMsg, DexterAdapterInstantiateMsg, ExecuteMsg,
-        MigrateMsg, QueryMsg, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse,
-        SwapOperation,
+        MigrateMsg, QueryMsg, Route, SimulateSwapExactAssetInResponse,
+        SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 
@@ -102,15 +101,7 @@ pub fn receive_cw20(
     info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
 
     match from_json(&cw20_msg.msg)? {
-        Cw20HookMsg::Swap { routes } => {
-            if routes.len() != 1 {
-                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
-            }
-
-            let operations = routes.first().unwrap().operations.clone();
-
-            execute_swap(deps, env, info, sent_asset.amount(), operations)
-        }
+        Cw20HookMsg::Swap { routes } => execute_swap(deps, env, info, routes),
     }
 }
 
@@ -128,25 +119,9 @@ pub fn execute(
     match msg {
         ExecuteMsg::Receive(cw20_msg) => receive_cw20(deps, env, info, cw20_msg),
         ExecuteMsg::Swap { routes } => {
-            if routes.len() != 1 {
-                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
-            }
+            one_coin(&info)?;
 
-            let operations = routes.first().unwrap().operations.clone();
-
-            // validate that there's at least one swap operation
-            if operations.is_empty() {
-                return Err(ContractError::SwapOperationsEmpty);
-            }
-
-            let coin = one_coin(&info)?;
-
-            // validate that the one coin is the same as the first swap operation's denom in
-            if coin.denom != operations.first().unwrap().denom_in {
-                return Err(ContractError::CoinInDenomMismatch);
-            }
-
-            execute_swap(deps, env, info, coin.amount, operations)
+            execute_swap(deps, env, info, routes)
         }
         ExecuteMsg::TransferFundsBack {
             swapper,
@@ -168,8 +143,7 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    amount_in: Uint128,
-    operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -181,44 +155,51 @@ fn execute_swap(
     }
 
     // Create a response object to return
-    let response: Response = Response::new().add_attribute("action", "execute_swap");
+    let mut response: Response = Response::new().add_attribute("action", "execute_swap");
 
-    let mut hop_swap_requests = vec![];
+    for route in &routes {
+        let mut hop_swap_requests = vec![];
 
-    for operation in &operations {
-        let pool_id: u64 = operation
-            .pool
-            .parse()
-            .map_err(|_| ContractError::PoolIdParseError)?;
-        let pool_id_u128 = Uint128::from(pool_id);
+        for operation in &route.operations {
+            let pool_id: u64 = operation
+                .pool
+                .parse()
+                .map_err(|_| ContractError::PoolIdParseError)?;
+            let pool_id_u128 = Uint128::from(pool_id);
 
-        hop_swap_requests.push(HopSwapRequest {
-            pool_id: pool_id_u128,
-            asset_in: dexter::asset::AssetInfo::native_token(operation.denom_in.clone()),
-            asset_out: dexter::asset::AssetInfo::native_token(operation.denom_out.clone()),
-        });
+            hop_swap_requests.push(HopSwapRequest {
+                pool_id: pool_id_u128,
+                asset_in: dexter::asset::AssetInfo::native_token(operation.denom_in.clone()),
+                asset_out: dexter::asset::AssetInfo::native_token(operation.denom_out.clone()),
+            });
+        }
+
+        let dexter_router_msg = RouterExecuteMsg::ExecuteMultihopSwap {
+            requests: hop_swap_requests,
+            recipient: None,
+            offer_amount: route.offer_asset.amount(),
+            // doing this since we would validate it anyway in the entrypoint contract from where swap adapter is called
+            minimum_receive: None,
+        };
+
+        // let denom_in = route.operations.first().unwrap().denom_in.clone();
+
+        let dexter_router_wasm_msg = WasmMsg::Execute {
+            contract_addr: dexter_router_contract_address.to_string(),
+            msg: to_json_binary(&dexter_router_msg)?,
+            funds: vec![Coin {
+                denom: route.offer_asset.denom().to_string(),
+                amount: route.offer_asset.amount(),
+            }],
+        };
+
+        response = response.add_message(dexter_router_wasm_msg);
     }
 
-    let dexter_router_msg = RouterExecuteMsg::ExecuteMultihopSwap {
-        requests: hop_swap_requests,
-        recipient: None,
-        offer_amount: amount_in,
-        // doing this since we would validate it anyway in the entrypoint contract from where swap adapter is called
-        minimum_receive: None,
-    };
-
-    let denom_in = operations.first().unwrap().denom_in.clone();
-
-    let dexter_router_wasm_msg = WasmMsg::Execute {
-        contract_addr: dexter_router_contract_address.to_string(),
-        msg: to_json_binary(&dexter_router_msg)?,
-        funds: vec![Coin {
-            denom: denom_in,
-            amount: amount_in,
-        }],
-    };
-
-    let return_denom = match operations.last() {
+    let return_denom = match routes
+        .last()
+        .and_then(|last_route| last_route.operations.last())
+    {
         Some(last_op) => last_op.denom_out.clone(),
         None => return Err(ContractError::SwapOperationsEmpty),
     };
@@ -234,7 +215,6 @@ fn execute_swap(
     };
 
     Ok(response
-        .add_message(dexter_router_wasm_msg)
         .add_message(transfer_funds_back_msg)
         .add_attribute("action", "dispatch_swaps_and_transfer_back"))
 }

--- a/contracts/adapters/swap/dexter/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/dexter/tests/test_execute_swap.rs
@@ -38,8 +38,7 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
-    offer_asset: Asset,
-    swap_operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
     expected_messages: Vec<SubMsg>,
     expected_error_string: String,
 }
@@ -49,13 +48,17 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "uxprt")],
-        offer_asset: Asset::Native(Coin::new(100, "uxprt")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "1".to_string(),
-                denom_in: "uxprt".to_string(),
-                denom_out: "stk/uxprt".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "uxprt")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "1".to_string(),
+                        denom_in: "uxprt".to_string(),
+                        denom_out: "stk/uxprt".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![
@@ -109,19 +112,23 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "uatom".to_string(),
-                interface: None,
-            },
-            SwapOperation {
-                pool: "2".to_string(),
-                denom_in: "uatom".to_string(),
-                denom_out: "untrn".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "uatom".to_string(),
+                        interface: None,
+                    },
+                    SwapOperation {
+                        pool: "2".to_string(),
+                        denom_in: "uatom".to_string(),
+                        denom_out: "untrn".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![
@@ -184,8 +191,131 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(50, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "uatom".to_string(),
+                        interface: None,
+                    },
+                ],
+            },
+            Route {
+                offer_asset: Asset::Native(Coin::new(50, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "2".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "untrn".to_string(),
+                        interface: None,
+                    },
+                    SwapOperation {
+                        pool: "3".to_string(),
+                        denom_in: "untrn".to_string(),
+                        denom_out: "uatom".to_string(),
+                        interface: None,
+                    },
+                ],
+            },
+        ],
+        expected_messages: vec![
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "dexter_router".to_string(),
+                    msg: to_json_binary(& DexterRouterExecuteMsg::ExecuteMultihopSwap {
+                        requests: vec![
+                           HopSwapRequest {
+                                pool_id: Uint128::from(1u128),
+                                asset_in: DexterAssetInfo::NativeToken {
+                                        denom: "os".to_string()
+                                },
+                                asset_out: DexterAssetInfo::NativeToken {
+                                        denom: "uatom".to_string()
+                                },
+                            },
+                        ],
+                        offer_amount: Uint128::from(50u128),
+                        recipient: None,
+                        minimum_receive: None
+                    })?,
+                    funds: vec![
+                        Coin::new(50, "os")
+                    ],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "dexter_router".to_string(),
+                    msg: to_json_binary(& DexterRouterExecuteMsg::ExecuteMultihopSwap {
+                        requests: vec![
+                           HopSwapRequest {
+                                pool_id: Uint128::from(2u128),
+                                asset_in: DexterAssetInfo::NativeToken {
+                                        denom: "os".to_string()
+                                },
+                                asset_out: DexterAssetInfo::NativeToken {
+                                        denom: "untrn".to_string()
+                                },
+                            },
+                            HopSwapRequest {
+                                pool_id: Uint128::from(3u128),
+                                asset_in: DexterAssetInfo::NativeToken {
+                                        denom: "untrn".to_string()
+                                },
+                                asset_out: DexterAssetInfo::NativeToken {
+                                        denom: "uatom".to_string()
+                                },
+                            },
+                        ],
+                        offer_amount: Uint128::from(50u128),
+                        recipient: None,
+                        minimum_receive: None
+                    })?,
+                    funds: vec![
+                        Coin::new(50, "os")
+                    ],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+            SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "swap_contract_address".to_string(),
+                    msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                        return_denom: "uatom".to_string(),
+                        swapper: Addr::unchecked("entry_point"),
+                    })?,
+                    funds: vec![],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never,
+            },
+        ],
+        expected_error_string: "".to_string(),
+    };
+    "Multiple Routes"
+)]
+#[test_case(
+    Params {
+        caller: "entry_point".to_string(),
+        info_funds: vec![Coin::new(100, "os")],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![],
+            }
+        ],
         expected_messages: vec![
             SubMsg {
                 id: 0,
@@ -223,13 +353,17 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "uatom".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "uatom".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![],
@@ -243,13 +377,17 @@ struct Params {
             Coin::new(100, "os"),
             Coin::new(100, "uatom"),
         ],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "uatom".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "uatom".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![],
@@ -260,13 +398,17 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "pool_1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "uatom".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "uatom".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![],
@@ -280,13 +422,17 @@ struct Params {
             Coin::new(100, "uxprt"),
             // Coin::new(100, "os"),
         ],
-        offer_asset: Asset::Native(Coin::new(100, "uxprt")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "1".to_string(),
-                denom_in: "uxprt".to_string(),
-                denom_out: "stk/uxprt".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "uxprt")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "1".to_string(),
+                        denom_in: "uxprt".to_string(),
+                        denom_out: "stk/uxprt".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![],
@@ -318,10 +464,7 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            routes: vec![Route {
-                offer_asset: params.offer_asset,
-                operations: params.swap_operations.clone(),
-            }],
+            routes: params.routes,
         },
     );
 

--- a/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
+++ b/contracts/adapters/swap/osmosis-poolmanager/src/contract.rs
@@ -9,17 +9,17 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw_utils::one_coin;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
-    EstimateSwapExactAmountInResponse, EstimateSwapExactAmountOutResponse, MsgSwapExactAmountIn,
-    PoolmanagerQuerier, SpotPriceResponse, SwapAmountInRoute, SwapAmountOutRoute,
+    EstimateSwapExactAmountInResponse, EstimateSwapExactAmountOutResponse,
+    MsgSplitRouteSwapExactAmountIn, MsgSwapExactAmountIn, PoolmanagerQuerier, SpotPriceResponse,
+    SwapAmountInRoute, SwapAmountInSplitRoute, SwapAmountOutRoute,
 };
 use skip::{
     asset::Asset,
-    error::SkipError,
     proto_coin::ProtoCoin,
     swap::{
-        convert_swap_operations, execute_transfer_funds_back, ExecuteMsg, InstantiateMsg,
-        MigrateMsg, QueryMsg, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse,
-        SwapOperation,
+        convert_routes, convert_swap_operations, execute_transfer_funds_back, ExecuteMsg,
+        InstantiateMsg, MigrateMsg, QueryMsg, Route, SimulateSwapExactAssetInResponse,
+        SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 use std::str::FromStr;
@@ -78,15 +78,7 @@ pub fn execute(
     msg: ExecuteMsg,
 ) -> ContractResult<Response> {
     match msg {
-        ExecuteMsg::Swap { routes } => {
-            if routes.len() != 1 {
-                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
-            }
-
-            let operations = routes.first().unwrap().operations.clone();
-
-            execute_swap(deps, env, info, operations)
-        }
+        ExecuteMsg::Swap { routes } => execute_swap(deps, env, info, routes),
         ExecuteMsg::TransferFundsBack {
             swapper,
             return_denom,
@@ -108,7 +100,7 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -121,13 +113,16 @@ fn execute_swap(
     // Get coin in from the message info, error if there is not exactly one coin sent
     let coin_in = one_coin(&info)?;
 
-    let return_denom = match operations.last() {
+    let return_denom = match routes
+        .last()
+        .and_then(|last_route| last_route.operations.last())
+    {
         Some(last_op) => last_op.denom_out.clone(),
         None => return Err(ContractError::SwapOperationsEmpty),
     };
 
     // Create the osmosis poolmanager swap exact amount in message
-    let swap_msg = create_osmosis_swap_msg(&env, coin_in, operations)?;
+    let swap_msg = create_osmosis_swap_msg(&env, coin_in, routes)?;
 
     // Create the transfer funds back message
     let transfer_funds_back_msg = WasmMsg::Execute {
@@ -153,22 +148,45 @@ fn execute_swap(
 fn create_osmosis_swap_msg(
     env: &Env,
     coin_in: Coin,
-    swap_operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
 ) -> ContractResult<CosmosMsg> {
-    // Convert the swap operations to osmosis swap amount in routes
-    // Return an error if there was an error converting the swap
-    // operations to osmosis swap amount in routes.
-    let osmosis_swap_amount_in_routes: Vec<SwapAmountInRoute> =
-        convert_swap_operations(swap_operations).map_err(ContractError::ParseIntPoolID)?;
+    if routes.len() == 1 {
+        let swap_operations = routes.first().unwrap().operations.clone();
 
-    // Create the osmosis poolmanager swap exact amount in message
+        // Convert the swap operations to osmosis swap amount in routes
+        // Return an error if there was an error converting the swap
+        // operations to osmosis swap amount in routes.
+        let osmosis_swap_amount_in_routes: Vec<SwapAmountInRoute> =
+            convert_swap_operations(swap_operations).map_err(ContractError::ParseIntPoolID)?;
+
+        // Create the osmosis poolmanager swap exact amount in message
+        // The token out min amount is set to 1 because we are not concerned
+        // with the minimum amount in this contract, that gets verified in the
+        // entry point contract.
+        let swap_msg: CosmosMsg = MsgSwapExactAmountIn {
+            sender: env.contract.address.to_string(),
+            routes: osmosis_swap_amount_in_routes,
+            token_in: Some(ProtoCoin(coin_in).into()),
+            token_out_min_amount: "1".to_string(),
+        }
+        .into();
+
+        return Ok(swap_msg);
+    }
+
+    // Convert the swap operations to osmosis swap amount in split routes
+    // Return an error if there was an error converting the swap
+    // operations to osmosis swap amount in split routes.
+    let osmosis_swap_amount_in_split_routes: Vec<SwapAmountInSplitRoute> = convert_routes(routes)?;
+
+    // Create the osmosis poolmanager split route swap exact amount in message
     // The token out min amount is set to 1 because we are not concerned
     // with the minimum amount in this contract, that gets verified in the
     // entry point contract.
-    let swap_msg: CosmosMsg = MsgSwapExactAmountIn {
+    let swap_msg: CosmosMsg = MsgSplitRouteSwapExactAmountIn {
         sender: env.contract.address.to_string(),
-        routes: osmosis_swap_amount_in_routes,
-        token_in: Some(ProtoCoin(coin_in).into()),
+        routes: osmosis_swap_amount_in_split_routes,
+        token_in_denom: coin_in.denom,
         token_out_min_amount: "1".to_string(),
     }
     .into();

--- a/contracts/adapters/swap/white-whale/src/contract.rs
+++ b/contracts/adapters/swap/white-whale/src/contract.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::{ContractError, ContractResult},
-    state::ENTRY_POINT_CONTRACT_ADDRESS,
+    state::{ENTRY_POINT_CONTRACT_ADDRESS, PRE_SWAP_OUT_ASSET_AMOUNT},
 };
 use cosmwasm_std::{
     entry_point, from_json, to_json_binary, Binary, Decimal, Deps, DepsMut, Env, MessageInfo,
@@ -11,10 +11,9 @@ use cw20::{Cw20Coin, Cw20ReceiveMsg};
 use cw_utils::one_coin;
 use skip::{
     asset::{get_current_asset_available, Asset},
-    error::SkipError,
     swap::{
         execute_transfer_funds_back, Cw20HookMsg, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
-        SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
+        Route, SimulateSwapExactAssetInResponse, SimulateSwapExactAssetOutResponse, SwapOperation,
     },
 };
 use white_whale_std::pool_network::{
@@ -90,15 +89,7 @@ pub fn receive_cw20(
     info.sender = deps.api.addr_validate(&cw20_msg.sender)?;
 
     match from_json(&cw20_msg.msg)? {
-        Cw20HookMsg::Swap { routes } => {
-            if routes.len() != 1 {
-                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
-            }
-
-            let operations = routes.first().unwrap().operations.clone();
-
-            execute_swap(deps, env, info, operations)
-        }
+        Cw20HookMsg::Swap { routes } => execute_swap(deps, env, info, routes),
     }
 }
 
@@ -118,13 +109,7 @@ pub fn execute(
         ExecuteMsg::Swap { routes } => {
             one_coin(&info)?;
 
-            if routes.len() != 1 {
-                return Err(ContractError::Skip(SkipError::MustBeSingleRoute));
-            }
-
-            let operations = routes.first().unwrap().operations.clone();
-
-            execute_swap(deps, env, info, operations)
+            execute_swap(deps, env, info, routes)
         }
         ExecuteMsg::TransferFundsBack {
             swapper,
@@ -136,9 +121,10 @@ pub fn execute(
             swapper,
             return_denom,
         )?),
-        ExecuteMsg::WhiteWhalePoolSwap { operation } => {
-            execute_white_whale_pool_swap(deps, env, info, operation)
-        }
+        ExecuteMsg::WhiteWhalePoolSwap {
+            operation,
+            offer_asset,
+        } => execute_white_whale_pool_swap(deps, env, info, operation, offer_asset),
         _ => {
             unimplemented!()
         }
@@ -149,7 +135,7 @@ fn execute_swap(
     deps: DepsMut,
     env: Env,
     info: MessageInfo,
-    operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
 ) -> ContractResult<Response> {
     // Get entry point contract address from storage
     let entry_point_contract_address = ENTRY_POINT_CONTRACT_ADDRESS.load(deps.storage)?;
@@ -159,22 +145,40 @@ fn execute_swap(
         return Err(ContractError::Unauthorized);
     }
 
+    // reset the pre swap out asset amount
+    PRE_SWAP_OUT_ASSET_AMOUNT.save(deps.storage, &Uint128::new(0))?;
+
     // Create a response object to return
     let mut response: Response = Response::new().add_attribute("action", "execute_swap");
 
     // Add a white whale pool swap message to the response for each swap operation
-    for operation in &operations {
-        let swap_msg = WasmMsg::Execute {
-            contract_addr: env.contract.address.to_string(),
-            msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
-                operation: operation.clone(),
-            })?,
-            funds: vec![],
-        };
-        response = response.add_message(swap_msg);
+    for route in &routes {
+        for (idx, operation) in route.operations.iter().enumerate() {
+            // if first operation in a route, set offer asset to the route's offer asset
+            // otherwise, the offer asset will be determined by the contracts balance
+            let offer_asset = if idx == 0 {
+                Some(route.offer_asset.clone())
+            } else {
+                None
+            };
+
+            let swap_msg = WasmMsg::Execute {
+                contract_addr: env.contract.address.to_string(),
+                msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                    operation: operation.clone(),
+                    offer_asset,
+                })?,
+                funds: vec![],
+            };
+
+            response = response.add_message(swap_msg);
+        }
     }
 
-    let return_denom = match operations.last() {
+    let return_denom = match routes
+        .last()
+        .and_then(|last_route| last_route.operations.last())
+    {
         Some(last_op) => last_op.denom_out.clone(),
         None => return Err(ContractError::SwapOperationsEmpty),
     };
@@ -199,6 +203,7 @@ fn execute_white_whale_pool_swap(
     env: Env,
     info: MessageInfo,
     operation: SwapOperation,
+    offer_asset: Option<Asset>,
 ) -> ContractResult<Response> {
     // Ensure the caller is the contract itself
     if info.sender != env.contract.address {
@@ -206,12 +211,30 @@ fn execute_white_whale_pool_swap(
     }
 
     // Get the current asset available on contract to swap in
-    let offer_asset = get_current_asset_available(&deps, &env, &operation.denom_in)?;
+    let offer_asset = match offer_asset {
+        Some(offer_asset) => offer_asset,
+        None => {
+            let pre_swap_out_asset_amount = PRE_SWAP_OUT_ASSET_AMOUNT
+                .load(deps.storage)
+                .unwrap_or(Uint128::zero());
+
+            let mut current_balance =
+                get_current_asset_available(&deps, &env, &operation.denom_in)?;
+
+            current_balance.sub(pre_swap_out_asset_amount)?;
+
+            current_balance
+        }
+    };
 
     // Error if the offer asset amount is zero
     if offer_asset.amount().is_zero() {
         return Err(ContractError::NoOfferAssetAmount);
     }
+
+    let pre_swap_out_asset_amount =
+        get_current_asset_available(&deps, &env, operation.denom_out.as_str())?.amount();
+    PRE_SWAP_OUT_ASSET_AMOUNT.save(deps.storage, &pre_swap_out_asset_amount)?;
 
     // Create the whitewhale pool swap msg depending on the offer asset type
     let msg = match offer_asset {

--- a/contracts/adapters/swap/white-whale/src/state.rs
+++ b/contracts/adapters/swap/white-whale/src/state.rs
@@ -1,4 +1,6 @@
-use cosmwasm_std::Addr;
+use cosmwasm_std::{Addr, Uint128};
 use cw_storage_plus::Item;
 
 pub const ENTRY_POINT_CONTRACT_ADDRESS: Item<Addr> = Item::new("entry_point_contract_address");
+
+pub const PRE_SWAP_OUT_ASSET_AMOUNT: Item<Uint128> = Item::new("pre_swap_out_asset_amount");

--- a/contracts/adapters/swap/white-whale/tests/test_execute_receive.rs
+++ b/contracts/adapters/swap/white-whale/tests/test_execute_receive.rs
@@ -63,6 +63,10 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                        offer_asset: Some(Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(100u128)
+                        })),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "neutron123".to_string(),
@@ -115,6 +119,10 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                        offer_asset: Some(Asset::Cw20(Cw20Coin {
+                            address: "neutron123".to_string(),
+                            amount: Uint128::from(100u128)
+                        })),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "neutron123".to_string(),

--- a/contracts/adapters/swap/white-whale/tests/test_execute_swap.rs
+++ b/contracts/adapters/swap/white-whale/tests/test_execute_swap.rs
@@ -33,8 +33,9 @@ Expect Error
 struct Params {
     caller: String,
     info_funds: Vec<Coin>,
-    offer_asset: Asset,
-    swap_operations: Vec<SwapOperation>,
+    // offer_asset: Asset,
+    // swap_operations: Vec<SwapOperation>,
+    routes: Vec<Route>,
     expected_messages: Vec<SubMsg>,
     expected_error: Option<ContractError>,
 }
@@ -44,13 +45,17 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "pool_1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "ua".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "ua".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![
@@ -59,6 +64,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                        offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "os".to_string(),
@@ -93,19 +99,23 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![
-            SwapOperation {
-                pool: "pool_1".to_string(),
-                denom_in: "os".to_string(),
-                denom_out: "ua".to_string(),
-                interface: None,
-            },
-            SwapOperation {
-                pool: "pool_2".to_string(),
-                denom_in: "ua".to_string(),
-                denom_out: "un".to_string(),
-                interface: None,
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![
+                    SwapOperation {
+                        pool: "pool_1".to_string(),
+                        denom_in: "os".to_string(),
+                        denom_out: "ua".to_string(),
+                        interface: None,
+                    },
+                    SwapOperation {
+                        pool: "pool_2".to_string(),
+                        denom_in: "ua".to_string(),
+                        denom_out: "un".to_string(),
+                        interface: None,
+                    }
+                ],
             }
         ],
         expected_messages: vec![
@@ -114,6 +124,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                        offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
                         operation: SwapOperation {
                             pool: "pool_1".to_string(),
                             denom_in: "os".to_string(),
@@ -131,6 +142,7 @@ struct Params {
                 msg: WasmMsg::Execute {
                     contract_addr: "swap_contract_address".to_string(),
                     msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                        offer_asset: None,
                         operation: SwapOperation {
                             pool: "pool_2".to_string(),
                             denom_in: "ua".to_string(),
@@ -162,11 +174,119 @@ struct Params {
     };
     "Multiple Swap Operations")]
 #[test_case(
+        Params {
+            caller: "entry_point".to_string(),
+            info_funds: vec![Coin::new(100, "os")],
+            routes: vec![
+                Route {
+                    offer_asset: Asset::Native(Coin::new(25, "os")),
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool_1".to_string(),
+                            denom_in: "os".to_string(),
+                            denom_out: "ua".to_string(),
+                            interface: None,
+                        },
+                        SwapOperation {
+                            pool: "pool_2".to_string(),
+                            denom_in: "ua".to_string(),
+                            denom_out: "un".to_string(),
+                            interface: None,
+                        }
+                    ],
+                },
+                Route {
+                    offer_asset: Asset::Native(Coin::new(75, "os")),
+                    operations: vec![
+                        SwapOperation {
+                            pool: "pool_3".to_string(),
+                            denom_in: "os".to_string(),
+                            denom_out: "un".to_string(),
+                            interface: None,
+                        },
+                    ],
+                }
+            ],
+            expected_messages: vec![
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                            offer_asset: Some(Asset::Native(Coin::new(25, "os"))),
+                            operation: SwapOperation {
+                                pool: "pool_1".to_string(),
+                                denom_in: "os".to_string(),
+                                denom_out: "ua".to_string(),
+                                interface: None,
+                            }
+                        })?,
+                        funds: vec![],
+                    }.into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                            offer_asset: None,
+                            operation: SwapOperation {
+                                pool: "pool_2".to_string(),
+                                denom_in: "ua".to_string(),
+                                denom_out: "un".to_string(),
+                                interface: None,
+                            }
+                        })?,
+                        funds: vec![],
+                    }.into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::WhiteWhalePoolSwap {
+                            offer_asset: Some(Asset::Native(Coin::new(75, "os"))),
+                            operation: SwapOperation {
+                                pool: "pool_3".to_string(),
+                                denom_in: "os".to_string(),
+                                denom_out: "un".to_string(),
+                                interface: None,
+                            }
+                        })?,
+                        funds: vec![],
+                    }.into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+                SubMsg {
+                    id: 0,
+                    msg: WasmMsg::Execute {
+                        contract_addr: "swap_contract_address".to_string(),
+                        msg: to_json_binary(&ExecuteMsg::TransferFundsBack {
+                            return_denom: "un".to_string(),
+                            swapper: Addr::unchecked("entry_point"),
+                        })?,
+                        funds: vec![],
+                    }
+                    .into(),
+                    gas_limit: None,
+                    reply_on: Never,
+                },
+            ],
+            expected_error: None,
+        };
+        "Multiple Routes")]
+#[test_case(
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![Coin::new(100, "os")],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        // offer_asset: Asset::Native(Coin::new(100, "os")),
+        // swap_operations: vec![],        
+        routes: vec![],
         expected_messages: vec![],
         expected_error: Some(ContractError::SwapOperationsEmpty),
     };
@@ -175,8 +295,12 @@ struct Params {
     Params {
         caller: "entry_point".to_string(),
         info_funds: vec![],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![],
+            }
+        ],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::NoFunds{})),
     };
@@ -188,8 +312,12 @@ struct Params {
             Coin::new(100, "un"),
             Coin::new(100, "os"),
         ],
-        offer_asset: Asset::Native(Coin::new(100, "os")),
-        swap_operations: vec![],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "os")),
+                operations: vec![],
+            }
+        ],
         expected_messages: vec![],
         expected_error: Some(ContractError::Payment(cw_utils::PaymentError::MultipleDenoms{})),
     };
@@ -200,8 +328,12 @@ struct Params {
         info_funds: vec![
             Coin::new(100, "un"),
         ],
-        offer_asset: Asset::Native(Coin::new(100, "un")),
-        swap_operations: vec![],
+        routes: vec![
+            Route {
+                offer_asset: Asset::Native(Coin::new(100, "un")),
+                operations: vec![],
+            }
+        ],
         expected_messages: vec![],
         expected_error: Some(ContractError::Unauthorized),
     };
@@ -229,10 +361,7 @@ fn test_execute_swap(params: Params) -> ContractResult<()> {
         env,
         info,
         ExecuteMsg::Swap {
-            routes: vec![Route {
-                offer_asset: params.offer_asset,
-                operations: params.swap_operations,
-            }],
+            routes: params.routes,
         },
     );
 

--- a/contracts/adapters/swap/white-whale/tests/test_execute_white_whale_pool_swap.rs
+++ b/contracts/adapters/swap/white-whale/tests/test_execute_white_whale_pool_swap.rs
@@ -4,9 +4,15 @@ use cosmwasm_std::{
     ReplyOn::Never,
     SubMsg, SystemResult, Uint128, WasmMsg, WasmQuery,
 };
-use cw20::{BalanceResponse, Cw20ExecuteMsg};
-use skip::swap::{ExecuteMsg, SwapOperation};
-use skip_api_swap_adapter_white_whale::error::{ContractError, ContractResult};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ExecuteMsg};
+use skip::{
+    asset::Asset,
+    swap::{ExecuteMsg, SwapOperation},
+};
+use skip_api_swap_adapter_white_whale::{
+    error::{ContractError, ContractResult},
+    state::PRE_SWAP_OUT_ASSET_AMOUNT,
+};
 use test_case::test_case;
 use white_whale_std::pool_network::{
     asset::{Asset as WhiteWhaleAsset, AssetInfo},
@@ -31,6 +37,8 @@ Expect Error
 struct Params {
     caller: String,
     contract_balance: Vec<Coin>,
+    pre_swap_out_asset_amount: Uint128,
+    offer_asset: Option<Asset>,
     swap_operation: SwapOperation,
     expected_message: Option<SubMsg>,
     expected_error: Option<ContractError>,
@@ -41,6 +49,8 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![Coin::new(100, "os")],
+        pre_swap_out_asset_amount: Uint128::new(0),
+        offer_asset: Some(Asset::Native(Coin::new(100, "os"))),
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "os".to_string(),
@@ -75,6 +85,11 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        pre_swap_out_asset_amount: Uint128::new(0),
+        offer_asset: Some(Asset::Cw20(Cw20Coin {
+            address: "neutron123".to_string(),
+            amount: Uint128::from(100u128),
+        })),
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "neutron123".to_string(),
@@ -103,9 +118,48 @@ struct Params {
     };
     "Cw20 Swap Operation")]
 #[test_case(
+        Params {
+            caller: "swap_contract_address".to_string(),
+            contract_balance: vec![Coin::new(100, "os")],
+            pre_swap_out_asset_amount: Uint128::new(50),
+            offer_asset: None,
+            swap_operation: SwapOperation {
+                pool: "pool_1".to_string(),
+                denom_in: "os".to_string(),
+                denom_out: "ua".to_string(),
+                interface: None,
+            },
+            expected_message: Some(SubMsg {
+                id: 0,
+                msg: WasmMsg::Execute {
+                    contract_addr: "pool_1".to_string(),
+                    msg: to_json_binary(&WhiteWhalePairExecuteMsg::Swap {
+                        offer_asset: WhiteWhaleAsset {
+                            info: AssetInfo::NativeToken {
+                                denom: "os".to_string(),
+                            },
+                            amount: Uint128::new(50),
+                        },
+                        belief_price: None,
+                        max_spread: Some(Decimal::percent(50)),
+                        to: None,
+                    })?,
+                    funds: vec![Coin::new(50, "os")],
+                }
+                .into(),
+                gas_limit: None,
+                reply_on: Never
+            }),
+            expected_error: None,
+        };
+        "Deducts pre swap out asset amount from contract balance before swap"
+    )]
+#[test_case(
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        pre_swap_out_asset_amount: Uint128::new(0),
+        offer_asset: None,
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "os".to_string(),
@@ -120,6 +174,8 @@ struct Params {
     Params {
         caller: "swap_contract_address".to_string(),
         contract_balance: vec![],
+        pre_swap_out_asset_amount: Uint128::new(0),
+        offer_asset: None,
         swap_operation: SwapOperation {
                 pool: "pool_1".to_string(),
                 denom_in: "randomcw20".to_string(),
@@ -136,6 +192,8 @@ struct Params {
         contract_balance: vec![
             Coin::new(100, "un"),
         ],
+        pre_swap_out_asset_amount: Uint128::new(0),
+        offer_asset: None,
         swap_operation: SwapOperation{
             pool: "".to_string(),
             denom_in: "".to_string(),
@@ -186,6 +244,8 @@ fn test_execute_white_whale_pool_swap(params: Params) -> ContractResult<()> {
     let mut env = mock_env();
     env.contract.address = Addr::unchecked("swap_contract_address");
 
+    PRE_SWAP_OUT_ASSET_AMOUNT.save(&mut deps.storage, &params.pre_swap_out_asset_amount)?;
+
     // Create mock info
     let info = mock_info(&params.caller, &[]);
 
@@ -196,6 +256,7 @@ fn test_execute_white_whale_pool_swap(params: Params) -> ContractResult<()> {
         info,
         ExecuteMsg::WhiteWhalePoolSwap {
             operation: params.swap_operation,
+            offer_asset: params.offer_asset,
         },
     );
 

--- a/packages/skip/src/swap.rs
+++ b/packages/skip/src/swap.rs
@@ -57,10 +57,22 @@ pub struct LidoSatelliteInstantiateMsg {
 #[cw_serde]
 pub enum ExecuteMsg {
     Receive(Cw20ReceiveMsg),
-    Swap { routes: Vec<Route> },
-    TransferFundsBack { swapper: Addr, return_denom: String },
-    AstroportPoolSwap { operation: SwapOperation }, // Only used for the astroport swap adapter contract
-    WhiteWhalePoolSwap { operation: SwapOperation }, // Only used for the white whale swap adapter contract
+    Swap {
+        routes: Vec<Route>,
+    },
+    TransferFundsBack {
+        swapper: Addr,
+        return_denom: String,
+    },
+    // Only used for the astroport swap adapter contract
+    AstroportPoolSwap {
+        operation: SwapOperation,
+    },
+    // Only used for the white whale swap adapter contract
+    WhiteWhalePoolSwap {
+        operation: SwapOperation,
+        offer_asset: Option<Asset>,
+    },
 }
 
 #[cw_serde]


### PR DESCRIPTION
Updates adapter contracts to support multiple routes. Excluding:
- Astroport added in #99 
- Lido Satellite, doesn't seem relevant

Updates `osmosis-std` to access split route types

**Note:** I checked the Dexter router code and they properly track balances between swaps so the edge case found in #99 won't be an issue.