### PR TITLE
[API-2920] emit swap denoms in event attributes

### DIFF
--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -315,7 +315,9 @@ pub fn execute_user_swap(
     }
 
     // Create a response object to return
-    let mut response: Response = Response::new().add_attribute("action", "execute_user_swap");
+    let mut response: Response = Response::new().add_attribute("action", "execute_user_swap")
+        .add_attribute("denom_in", remaining_asset.denom())
+        .add_attribute("denom_out", min_asset.denom());
 
     // Create affiliate response and total affiliate fee amount
     let mut affiliate_response: Response = Response::new();

--- a/contracts/entry-point/src/execute.rs
+++ b/contracts/entry-point/src/execute.rs
@@ -315,7 +315,8 @@ pub fn execute_user_swap(
     }
 
     // Create a response object to return
-    let mut response: Response = Response::new().add_attribute("action", "execute_user_swap")
+    let mut response: Response = Response::new()
+        .add_attribute("action", "execute_user_swap")
         .add_attribute("denom_in", remaining_asset.denom())
         .add_attribute("denom_out", min_asset.denom());
 


### PR DESCRIPTION
Adds code in the `execute_user_swap` handler that emits the swap denoms in the event attributes.